### PR TITLE
Node must assign hostname via first ping if not set by Arvados

### DIFF
--- a/services/api/app/controllers/arvados/v1/nodes_controller.rb
+++ b/services/api/app/controllers/arvados/v1/nodes_controller.rb
@@ -30,7 +30,8 @@ class Arvados::V1::NodesController < ApplicationController
         ip: params[:local_ipv4] || request.remote_ip,
         ec2_instance_id: params[:instance_id]
       }
-      [:ping_secret, :total_cpu_cores, :total_ram_mb, :total_scratch_mb]
+
+      [:ping_secret, :total_cpu_cores, :total_ram_mb, :total_scratch_mb, :hostname]
         .each do |key|
         ping_data[key] = params[key] if params[key]
       end

--- a/services/api/app/models/node.rb
+++ b/services/api/app/models/node.rb
@@ -124,8 +124,14 @@ class Node < ArvadosModel
     end
 
     # Assign hostname
-    if self.hostname.nil? and Rails.configuration.assign_node_hostname
-      self.hostname = self.class.hostname_for_slot(self.slot_number)
+    if self.hostname.nil?
+      if Rails.configuration.assign_node_hostname
+        self.hostname = self.class.hostname_for_slot(self.slot_number)
+      elsif o[:hostname]
+        self.hostname = o[:hostname]
+      else
+         raise "Hostname of Node nil and assign_node_hostname false, but no hostname was send in the initial ping"
+      end
     end
 
     # Record other basic stats


### PR DESCRIPTION
I experienced the issue that node `hostname`s   (from the Node model class) remain unassigned if 
`assign_node_hostname: false`
in the `application.yml`. 

I changed the logic such that the hostname must be included in the ping from the cloud node if
`assign_node_hostname: false`. The sent value will then be applied to the node model.
