### PR TITLE
enable universal wheels

### DIFF
--- a/sdk/python/setup.cfg
+++ b/sdk/python/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
please can you release wheels with:

```
pipx run --spec=build python-build --sdist --wheel
pipx run twine upload dist/*
```