### PR TITLE
Fix for preemptible instance

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,5 @@ Thomas Mooney <tmooney@genome.wustl.edu>
 Chen Chen <aflyhorse@gmail.com>
 Veritas Genetics, Inc. <*@veritasgenetics.com>
 Curii Corporation, Inc. <*@curii.com>
+Dante Tsang <dante@dantetsang.com>
+Codex Genetics Ltd <info@codexgenetics.com>

--- a/lib/dispatchcloud/container/queue.go
+++ b/lib/dispatchcloud/container/queue.go
@@ -382,7 +382,7 @@ func (cq *Queue) poll() (map[string]*arvados.Container, error) {
 			*next[upd.UUID] = upd
 		}
 	}
-	selectParam := []string{"uuid", "state", "priority", "runtime_constraints", "container_image", "mounts"}
+	selectParam := []string{"uuid", "state", "priority", "runtime_constraints", "container_image", "mounts", "scheduling_parameters"}
 	limitParam := 1000
 
 	mine, err := cq.fetchAll(arvados.ResourceListParams{


### PR DESCRIPTION
- Fixed FetchAll method for Container queue in order to make use of preemptible instance

The original poll method does not fetch scheduling_parameters from API so that the scheduling parameters will always be default value of the struct which is false. By adding "scheduling_parameters" to selectParam, the dispatcher can choose instance type correctly