### PR TITLE
Fix provision.sh for salt stack deployment

### DIFF
--- a/tools/salt-install/provision.sh
+++ b/tools/salt-install/provision.sh
@@ -50,6 +50,9 @@ VERSION="latest"
 
 set -o pipefail
 
+# capture the directory that the script is running from
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 usage() {
   echo >&2
   echo >&2 "Usage: $0 [-h] [-h]"
@@ -184,7 +187,7 @@ fi
 if [ "x${VAGRANT}" = "xyes" ]; then
   SOURCE_PILLARS_DIR="/vagrant/${CONFIG_DIR}"
 else
-  SOURCE_PILLARS_DIR="./${CONFIG_DIR}"
+  SOURCE_PILLARS_DIR="${SCRIPT_DIR}/${CONFIG_DIR}"
 fi
 
 # Replace cluster and domain name in the example pillars


### PR DESCRIPTION
In the provision.sh script that uses salt stack to setup Arvados, there is a [reference](https://github.com/arvados/arvados/blob/8876199fb07f53263cd431a8a5cb15f4b9444361/tools/salt-install/provision.sh#L187) to `./${CONFIG_DIR}` but this happens at a time when the script has already [changed directory](https://github.com/arvados/arvados/blob/8876199fb07f53263cd431a8a5cb15f4b9444361/tools/salt-install/provision.sh#L170) to a different location. This patch saves the script directory before that change and uses that path instead of `.`. 