### PR TITLE
Fix double slash in Version / debugging info window

### DIFF
--- a/apps/workbench/app/views/application/_report_issue_popup.html.erb
+++ b/apps/workbench/app/views/application/_report_issue_popup.html.erb
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0 %>
 
 <%
   generated_at = arvados_api_client.discovery[:generatedAt]
-  arvados_base = Rails.configuration.Services.Controller.ExternalURL.to_s + "/arvados/v1"
+  arvados_base = Rails.configuration.Services.Controller.ExternalURL.join("/arvados/v1").to_s
   support_email = Rails.configuration.Mail.SupportEmailAddress
 
   additional_info = {}

--- a/sdk/go/arvadostest/proxy.go
+++ b/sdk/go/arvadostest/proxy.go
@@ -28,7 +28,7 @@ type Proxy struct {
 	RequestDumps [][]byte
 }
 
-// NewProxy returns a new Proxy that saves a dump of each reqeust
+// NewProxy returns a new Proxy that saves a dump of each request
 // before forwarding to the indicated service.
 func NewProxy(c *check.C, svc arvados.Service) *Proxy {
 	var target url.URL

--- a/sdk/go/dispatch/dispatch.go
+++ b/sdk/go/dispatch/dispatch.go
@@ -325,7 +325,7 @@ func (d *Dispatcher) Unlock(uuid string) error {
 //
 // This allows the dispatcher to put its own RunContainer func into a
 // cleanup phase (for example, to kill local processes created by a
-// prevous dispatch process that are still running even though the
+// previous dispatch process that are still running even though the
 // container state is final) without the risk of having multiple
 // goroutines monitoring the same UUID.
 func (d *Dispatcher) TrackContainer(uuid string) error {


### PR DESCRIPTION
Hi,

Getting started with Arvados, using the public server first. When I clicked on the Version / debugging info, I noticed a double slash in one of the URL's in that page. While harmless, I thought that could be my first contribution to Arvados :slightly_smiling_face:  See screenshot below.

![image](https://user-images.githubusercontent.com/304786/141605884-dce26af3-9dcc-4ba2-b14a-8ae4e788de3c.png)

API Address shows two slashes, and I think it's due to the string concatenation of a configuration value with the `/arvados/v1`. My Ruby-Fu is really rusty, and I normally use Sinatra (for smashing/Smashing), but I think there's a `.join` method in the `URI` class that could be used. I will test it first and see if that takes care of extra slashes.

Still don't know how to run Arvados locally to see whether it fixed it or not, nor if there are no side-effects in using `.join` or similar methods. Will update the PR in the next hours/days once I learn more how to build & develop Arvados locally.

Thanks!
Bruno

p.s. one commit with some typos in comments, happy to drop the commit if others prefer to keep a single change in this PR :+1: 
