### PR TITLE
Fix collection tree caching bug

### DIFF
--- a/sdk/R/R/Collection.R
+++ b/sdk/R/R/Collection.R
@@ -391,7 +391,7 @@ Collection <- R6::R6Class(
         get = function(relativePath)
         {
             if(is.null(private$tree))
-                private$generateCollectionTreeStructure(relativePath)
+                private$generateCollectionTreeStructure()
 
             private$tree$getElement(relativePath)
         },

--- a/sdk/R/tests/testthat/fakes/FakeRESTService.R
+++ b/sdk/R/tests/testthat/fakes/FakeRESTService.R
@@ -146,7 +146,11 @@ FakeRESTService <- R6::R6Class(
         getCollectionContent = function(uuid, relativePath = NULL)
         {
             self$getCollectionContentCallCount <- self$getCollectionContentCallCount + 1
-            self$collectionContent
+            if (!is.null(relativePath)) {
+                self$collectionContent[startsWith(self$collectionContent, relativePath)]
+            } else {
+                self$collectionContent
+            }
         },
 
         getResourceSize = function(uuid, relativePathToResource)

--- a/sdk/R/tests/testthat/test-Collection.R
+++ b/sdk/R/tests/testthat/test-Collection.R
@@ -239,6 +239,12 @@ test_that("get returns arvados file or subcollection from internal tree structur
 
     expect_true(fishIsNotNull)
     expect_that(fish$getName(), equals("fish"))
+
+    ball <- collection$get("ball")
+    ballIsNotNull <- !is.null(ball)
+
+    expect_true(ballIsNotNull)
+    expect_that(ball$getName(), equals("ball"))
 })
 
 test_that(paste("copy copies content to a new location inside file tree",


### PR DESCRIPTION
Without this fix, accessing two files inside the same collection in succession via `collection$get` will fail on the second file because the private tree inside the `collection` is only populated with the relative path of the first file.

Here’s an MWE (requires a project UUID for an existing project, and appropriately configured API access credentials):

```r
api_token <- Sys.getenv("ARVADOS_API_TOKEN")
api_host <- Sys.getenv("ARVADOS_API_HOST")
# A blank project
project_uuid <- "PROJECT_UUID_HERE"

# Step 1: set up a test collection with files

arv <- ArvadosR::Arvados$new(api_token, api_host)

collection_uuid <- arv$collections_create(name = "arv-bug-mwe", description = "", ownerUUID = project_uuid)$uuid
collection <- ArvadosR::Collection$new(arv, collection_uuid)

filenames <- paste0("testfile", 1 : 2)
collection$create(filenames)

# Step 2: access the files

# Create a new connection to get a clean slate.
arv <- ArvadosR::Arvados$new(api_token, api_host)
collection <- ArvadosR::Collection$new(arv, collection_uuid)

# Order matters!
stopifnot(! is.null(collection$get(filenames[1L])))         # Works
stopifnot(! is.null(collection$get(filenames[2L])))         # Kablooie
stopifnot(all(filenames %in% collection$getFileListing()))  # But this works!
```

Step 1 makes the MWE self-contained, but it does not need to be re-executed to trigger the bug if an existing collection UUID with the files is provided. The files in this test are empty, but this fact is irrelevant.

Calling `collection$getFileListing()` *before* the first `collection$get` call prevents the buggy behaviour. But once `collection$get` is called once, subsequent calls for different files fail.