### PR TITLE
Fix for cached files from arvados-controller

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,3 +22,4 @@ Curii Corporation <*@curii.com>
 Dante Tsang <dante@dantetsang.com>
 Codex Genetics Ltd <info@codexgenetics.com>
 Bruno P. Kinoshita <brunodepaulak@yahoo.com.br>
+George Chlipala <gchlip2@uic.edu>

--- a/lib/controller/handler.go
+++ b/lib/controller/handler.go
@@ -282,7 +282,7 @@ func (ent *cacheEnt) refresh(path string, do func(*http.Request) (*http.Response
 	// 0.0.0.0:0 is just a placeholder here -- do(), which is
 	// localClusterRequest(), will replace the scheme and host
 	// parts with the real proxy destination.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://0.0.0.0:0/"+path, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost" + path, nil)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Updated handling of cached files in arvados-controller.   Fixes issue of serving of discovery document.    See discussion at https://matrix.to/#/!iCGZYZrhxQUZbnMoxM:gitter.im/$EXPq511LkcGX3bZ2khs--y-hfNhKPbPZ2PzM3ZbpX40?via=gitter.im&via=matrix.org
