### PR TITLE
In arv-copy command, fix name error in "except" clause

### DIFF
--- a/sdk/python/arvados/commands/arv_copy.py
+++ b/sdk/python/arvados/commands/arv_copy.py
@@ -642,7 +642,7 @@ def copy_collection(obj_uuid, src, dst, args):
                 logger.debug("Getting block %s", word)
                 data = src_keep.get(word)
                 put_queue.put((word, data))
-            except e:
+            except Exception as e:
                 logger.error("Error getting block %s: %s", word, e)
                 transfer_error.append(e)
                 try:
@@ -680,7 +680,7 @@ def copy_collection(obj_uuid, src, dst, args):
                     bytes_written += loc.size
                     if progress_writer:
                         progress_writer.report(obj_uuid, bytes_written, bytes_expected)
-            except e:
+            except Exception as e:
                 logger.error("Error putting block %s (%s bytes): %s", blockhash, loc.size, e)
                 try:
                     # Drain the 'get' queue so we end early


### PR DESCRIPTION
In arv_copy.py, when getting or putting (as part of "arv-copy" operation), the exception-handling clause had undefined names in themselves.  This would not only throw a hard error at the user but also prevent subsequent cleanup of the queues.

Fixed by binding the variable name to the exception.

Arvados-DCO-1.1-Signed-off-by: Zoë Ma <zoe.ma@curii.com>