### PR TITLE
Python and CWL command line tools: More robust handling of storage-class options

### DIFF
--- a/sdk/cwl/arvados_cwl/__init__.py
+++ b/sdk/cwl/arvados_cwl/__init__.py
@@ -29,6 +29,7 @@ import arvados.config
 import arvados.logging
 from arvados.keep import KeepClient
 from arvados.errors import ApiError
+from arvados.util import csv_to_list
 import arvados.commands._util as arv_cmd
 
 from .perf import Perf
@@ -183,9 +184,9 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
     parser.add_argument("--enable-dev", action="store_true",
                         help="Enable loading and running development versions "
                              "of the CWL standards.", default=False)
-    parser.add_argument('--storage-classes', default="default",
+    parser.add_argument('--storage-classes', default="",
                         help="Specify comma separated list of storage classes to be used when saving final workflow output to Keep.")
-    parser.add_argument('--intermediate-storage-classes', default="default",
+    parser.add_argument('--intermediate-storage-classes', default="",
                         help="Specify comma separated list of storage classes to be used when saving intermediate workflow output to Keep.")
 
     parser.add_argument("--intermediate-output-ttl", type=int, metavar="N",
@@ -329,6 +330,12 @@ def main(args=sys.argv[1:],
         job_order_object = ({}, "")
 
     add_arv_hints()
+
+    # Validate and clean-up the input arguments that take a value of
+    # comma-separated strings.
+    arvargs.varying_url_params = ",".join(csv_to_list(arvargs.varying_url_params))
+    arvargs.storage_classes = csv_to_list(arvargs.storage_classes)
+    arvargs.intermediate_storage_classes = csv_to_list(arvargs.intermediate_storage_classes)
 
     for key, val in cwltool.argparser.get_default_args().items():
         if not hasattr(arvargs, key):

--- a/sdk/cwl/arvados_cwl/arvcontainer.py
+++ b/sdk/cwl/arvados_cwl/arvcontainer.py
@@ -22,6 +22,7 @@ from cwltool.utils import aslist, adjustFileObjs, adjustDirObjs, visit_class
 from cwltool.job import JobBase
 
 import arvados.collection
+from arvados.util import storage_classes_from_config
 
 import crunchstat_summary.summarizer
 import crunchstat_summary.reader
@@ -307,7 +308,7 @@ class ArvadosContainer(JobBase):
             if storage_class_req and storage_class_req.get("intermediateStorageClass"):
                 container_request["output_storage_classes"] = aslist(storage_class_req["intermediateStorageClass"])
             else:
-                container_request["output_storage_classes"] = runtimeContext.intermediate_storage_classes.strip().split(",")
+                container_request["output_storage_classes"] = runtimeContext.intermediate_storage_classes or storage_classes_from_config(self.arvrunner.api.config())
 
         cuda_req, _ = self.get_requirement("http://commonwl.org/cwltool#CUDARequirement")
         if cuda_req:
@@ -751,11 +752,11 @@ class RunnerContainer(Runner):
         if runtimeContext.debug:
             command.append("--debug")
 
-        if runtimeContext.storage_classes != "default" and runtimeContext.storage_classes:
-            command.append("--storage-classes=" + runtimeContext.storage_classes)
+        if runtimeContext.storage_classes:
+            command.append("--storage-classes=" + ",".join(runtimeContext.storage_classes))
 
-        if runtimeContext.intermediate_storage_classes != "default" and runtimeContext.intermediate_storage_classes:
-            command.append("--intermediate-storage-classes=" + runtimeContext.intermediate_storage_classes)
+        if runtimeContext.intermediate_storage_classes:
+            command.append("--intermediate-storage-classes=" + ",".join(runtimeContext.intermediate_storage_classes))
 
         if runtimeContext.on_error:
             command.append("--on-error=" + self.on_error)
@@ -779,7 +780,7 @@ class RunnerContainer(Runner):
             command.append("--disable-preemptible")
 
         if runtimeContext.varying_url_params:
-            command.append("--varying-url-params="+runtimeContext.varying_url_params)
+            command.append("--varying-url-params=" + runtimeContext.varying_url_params)
 
         if runtimeContext.prefer_cached_downloads:
             command.append("--prefer-cached-downloads")

--- a/sdk/cwl/arvados_cwl/context.py
+++ b/sdk/cwl/arvados_cwl/context.py
@@ -29,8 +29,8 @@ class ArvRuntimeContext(RuntimeContext):
         self.submit_runner_image = None
         self.wait = True
         self.cwl_runner_job = None
-        self.storage_classes = "default"
-        self.intermediate_storage_classes = "default"
+        self.storage_classes = []
+        self.intermediate_storage_classes = []
         self.current_container = None
         self.http_timeout = 300
         self.submit_runner_cluster = None

--- a/sdk/cwl/arvados_cwl/executor.py
+++ b/sdk/cwl/arvados_cwl/executor.py
@@ -25,6 +25,7 @@ import arvados
 import arvados.config
 from arvados.keep import KeepClient
 from arvados.errors import ApiError
+from arvados.util import storage_classes_from_config
 
 import arvados_cwl.util
 from .arvcontainer import RunnerContainer, cleanup_name_for_collection
@@ -641,12 +642,6 @@ The 'jobs' API is no longer supported.
 
         runtimeContext = runtimeContext.copy()
 
-        default_storage_classes = ",".join([k for k,v in self.api.config().get("StorageClasses", {"default": {"Default": True}}).items() if v.get("Default") is True])
-        if runtimeContext.storage_classes == "default":
-            runtimeContext.storage_classes = default_storage_classes
-        if runtimeContext.intermediate_storage_classes == "default":
-            runtimeContext.intermediate_storage_classes = default_storage_classes
-
         if not runtimeContext.name:
             self.name = updated_tool.tool.get("label") or updated_tool.metadata.get("label") or os.path.basename(updated_tool.tool["id"])
             if git_info.get("http://arvados.org/cwl#gitDescribe"):
@@ -954,7 +949,7 @@ The 'jobs' API is no longer supported.
             if storage_class_req and storage_class_req.get("finalStorageClass"):
                 storage_classes = aslist(storage_class_req["finalStorageClass"])
             else:
-                storage_classes = runtimeContext.storage_classes.strip().split(",")
+                storage_classes = runtimeContext.storage_classes or storage_classes_from_config(self.api.config())
 
             output_properties = {}
             output_properties_req, _ = tool.get_requirement("http://arvados.org/cwl#OutputCollectionProperties")

--- a/sdk/python/arvados/_internal/http_to_keep.py
+++ b/sdk/python/arvados/_internal/http_to_keep.py
@@ -253,7 +253,7 @@ def check_cached_url(api, project_uuid, url, etags,
 
     logger.info("Checking Keep for %s", url)
 
-    varying_params = [s.strip() for s in varying_url_params.split(",")]
+    varying_params = arvados.util.csv_to_list(varying_url_params)
 
     parsed = urllib.parse.urlparse(url)
     query = [q for q in urllib.parse.parse_qsl(parsed.query)

--- a/sdk/python/arvados/commands/arv_copy.py
+++ b/sdk/python/arvados/commands/arv_copy.py
@@ -112,7 +112,7 @@ If not provided, will use the default client configuration from the environment 
         '--project-uuid', dest='project_uuid',
         help='The UUID of the project at the destination to which the collection or workflow should be copied.')
     copy_opts.add_argument(
-        '--storage-classes', dest='storage_classes',
+        '--storage-classes', dest='storage_classes', default="",
         help='Comma separated list of storage classes to be used when saving data to the destinaton Arvados instance.')
     copy_opts.add_argument("--varying-url-params", type=str, default="",
                         help="A comma separated list of URL query parameters that should be ignored when storing HTTP URLs in Keep.")
@@ -131,8 +131,7 @@ If not provided, will use the default client configuration from the environment 
         parents=[copy_opts, arv_cmd.retry_opt])
     args = parser.parse_args()
 
-    if args.storage_classes:
-        args.storage_classes = [x for x in args.storage_classes.strip().replace(' ', '').split(',') if x]
+    args.storage_classes = arvados.util.csv_to_list(args.storage_classes)
 
     if args.verbose:
         logger.setLevel(logging.DEBUG)
@@ -870,7 +869,8 @@ def uuid_type(api, object_uuid):
 def copy_from_http(url, src, dst, args):
 
     project_uuid = args.project_uuid
-    varying_url_params = args.varying_url_params
+    # Ensure string of varying parameters is well-formed
+    varying_url_params = ",".join(arvados.util.csv_to_list(args.varying_url_params))
     prefer_cached_downloads = args.prefer_cached_downloads
 
     cached = http_to_keep.check_cached_url(src, project_uuid, url, {},

--- a/sdk/python/arvados/commands/put.py
+++ b/sdk/python/arvados/commands/put.py
@@ -140,7 +140,7 @@ physical storage devices (e.g., disks) should have a copy of each data
 block. Default is to use the server-provided default (if any) or 2.
 """)
 
-upload_opts.add_argument('--storage-classes', help="""
+upload_opts.add_argument('--storage-classes', default="", help="""
 Specify comma separated list of storage classes to be used when saving data to Keep.
 """)
 
@@ -1221,9 +1221,9 @@ def main(arguments=None, stdout=sys.stdout, stderr=sys.stderr,
         reporter = None
 
     #  Split storage-classes argument
-    storage_classes = None
-    if args.storage_classes:
-        storage_classes = args.storage_classes.strip().replace(' ', '').split(',')
+    # Input may be pathological (empty string, all commas, etc.), which will be
+    # treated as if missing.
+    storage_classes = arvados.util.csv_to_list(args.storage_classes) or None
 
     # Setup exclude regex from all the --exclude arguments provided
     name_patterns = []

--- a/sdk/python/arvados/keep.py
+++ b/sdk/python/arvados/keep.py
@@ -770,7 +770,7 @@ class KeepClient(object):
             classes_confirmed = {}
             try:
                 scch = result['headers']['x-keep-storage-classes-confirmed']
-                for confirmation in scch.replace(' ', '').split(','):
+                for confirmation in arvados.util.csv_to_list(scch):
                     if '=' in confirmation:
                         stored_class, stored_copies = confirmation.split('=')[:2]
                         classes_confirmed[stored_class] = int(stored_copies)

--- a/sdk/python/arvados/util.py
+++ b/sdk/python/arvados/util.py
@@ -406,3 +406,32 @@ def csv_to_list(text: str) -> list[str]:
         if key:
             words[key] = None
     return list(words)
+
+def storage_classes_from_config(config: dict[str, Any], default_only: bool = True, fallback: str = "default") -> list[str]:
+    """Convenience function for getting the list of storage classes from the
+    API client config dict.
+
+    If `default_only` is True, only output those storage classes configured
+    with `Default` property.
+
+    If no configured storage classes (subject to the `default_only` option) can
+    be found, a fallback value as specified by the `fallback` parameter is used
+    as the sole element in the returned list. By convention, the value of the
+    fallback storage class is the string `"default"`.
+
+    This falling-back behavior is suppressed by setting `fallback` to an empty
+    string, in which case the output will be an empty list.
+
+    Arguments:
+
+        * config: dict[str, Any] -- API client config dictionary
+        * default_only: bool -- whether only the default storage classes should appear in the output; default: True
+        * fallback: str -- name of fallback storage class; default: `"default"`
+    """
+    storage_classes = []
+    for key, value in config.get("StorageClasses", {}).items():
+        if not default_only or value.get("Default") is True:
+            storage_classes.append(key)
+    if fallback and not storage_classes:
+        return [fallback]
+    return storage_classes

--- a/sdk/python/arvados/util.py
+++ b/sdk/python/arvados/util.py
@@ -378,3 +378,31 @@ def trim_name(collectionname: str) -> str:
         collectionname = collectionname[0:split] + "…" + collectionname[split+over:]
 
     return collectionname
+
+def csv_to_list(text: str) -> list[str]:
+    """Clean-up a string of comma-separated values by removing the leading and
+    trailing space characters in each element using the standard str.strip()
+    method. Then, any empty or repeated values are skipped.
+
+    Returns a list of strings as described above.  The values appear in the
+    original input order, up to repeated ones. If there are no valid values,
+    the output is an empty list. Elements of a non-empty output list are
+    guaranteed to be non-empty strings.
+
+    For example:
+        "a,b,a" -> ["a", "b"]
+        "a,,b," -> ["a", "b"]
+        ",b" -> ["b"]
+        "a, b" -> ["a", "b"]
+        ",," -> []
+
+    Arguments:
+
+    * text: str -- input string
+    """
+    words: dict[str, None] = {}  # preserve insertion order (since Python 3.6)
+    for word in text.split(","):
+        key = word.strip()
+        if key:
+            words[key] = None
+    return list(words)

--- a/sdk/python/tests/test_arv_put.py
+++ b/sdk/python/tests/test_arv_put.py
@@ -1442,6 +1442,11 @@ class ArvPutIntegrationTest(run_test_server.TestCaseWithServers,
         self.assertEqual(len(collection['storage_classes_desired']), 1)
         self.assertEqual(collection['storage_classes_desired'][0], 'default')
 
+    def test_put_collection_with_duplicate_and_malformed_storage_classes_specified(self):
+        collection = self.run_and_find_collection("", ['--storage-classes', ' foo, bar  ,baz,,  bar, foo, , ,'])
+        self.assertEqual(len(collection['storage_classes_desired']), 3)
+        self.assertEqual(collection['storage_classes_desired'], ['foo', 'bar', 'baz'])
+
     def test_exclude_filename_pattern(self):
         tmpdir = self.make_tmpdir()
         tmpsubdir = os.path.join(tmpdir, 'subdir')


### PR DESCRIPTION
For CLI clients (`arv-copy`, `arv-put`, `arvados-cwl-runner`), the user can specify the storage classes of output collections with options like `--storage-classes`, by passing the names of the classes as a comma-separated string.

We make the parsing of such arguments more resilient against invalid (e.g. all-blank) and duplicated input values. Specifically, the input string is split at the commas, and each segment is stripped of leading and trailing space characters. Then, empty values are discarded and duplicate values removed, with only the first appearances kept. (This is also reused for processing `--varying-url-params` etc.)

Moreover, for the CWL client in particular, we no longer use the hard-coded string `"default"` as the default value to the `--storage-classes` and `--intermediate-storage-classes` options. Instead, if the user does not explicitly specify any (valid) values (and none are specified in the CWL file's hints or requirements section), we gather and use the info about the real "default storage classes" as they are actually configured on the cluster where each container is to be run.

Internally, the `arvados_cwl.context.ArvRuntimeContext` object now stores the `storage_classes` and `intermediate_storage_classes` attributes as lists rather than strings. This, together with the decoupling of "using default classes" with "being equal to the magic string `"default"`", tends to simplify their processing in code elsewhere.

For the common use cases where the storage class "default" is indeed the only default storage class, the changes introduced here won't have any observable change of behavior.