### PR TITLE
21989: Keepstore: Use comma separator for X-Keep-Storage-Classes-Confirmed header

### DIFF
--- a/services/keepstore/router.go
+++ b/services/keepstore/router.go
@@ -128,7 +128,7 @@ func (rtr *router) handleBlockWrite(w http.ResponseWriter, req *http.Request) {
 	for k, n := range resp.StorageClasses {
 		if n > 0 {
 			if scc != "" {
-				scc += "; "
+				scc += ", "
 			}
 			scc += fmt.Sprintf("%s=%d", k, n)
 		}

--- a/services/keepstore/router_test.go
+++ b/services/keepstore/router_test.go
@@ -214,6 +214,11 @@ func (s *routerSuite) TestBlockWrite_Headers(c *C) {
 	c.Check(resp.Code, Equals, http.StatusOK)
 	c.Check(resp.Header().Get("X-Keep-Replicas-Stored"), Equals, "1")
 	c.Check(resp.Header().Get("X-Keep-Storage-Classes-Confirmed"), Equals, "testclass2=1")
+
+	resp = call(router, "PUT", "http://example/"+fooHash, arvadostest.ActiveTokenV2, []byte("foo"), http.Header{"X-Keep-Storage-Classes": []string{"testclass1, testclass2"}})
+	c.Check(resp.Code, Equals, http.StatusOK)
+	c.Check(resp.Header().Get("X-Keep-Replicas-Stored"), Equals, "2")
+	c.Check(resp.Header().Get("X-Keep-Storage-Classes-Confirmed"), Equals, "testclass1=1, testclass2=1")
 }
 
 func sortCommaSeparated(s string) string {


### PR DESCRIPTION
When generating the X-Keep-Storage-Classes-Confirmed header, use comma (",") instead of semicolon (";") as the separator for multi-entry value.

This is to be consistent with keep-proxy's behavior and the arv-put client's expectation. Plus, it follows RFC 9110 (see sec. 5.2).

Without the fix, arv-put wrongly believes that storage classes are not supported on the cluster it is putting to. The spurious warning "X-Keep-Storage-Classes header not supported by the cluster" can be seen in arv-put messages and in Workbench2.