### PR TITLE
22003: Workbench2 and keep-web: better interoperability with redirect

### DIFF
--- a/services/workbench2/src/common/redirect-to.ts
+++ b/services/workbench2/src/common/redirect-to.ts
@@ -55,19 +55,21 @@ export const handleRedirects = (token: string, config: Config) => {
         redirectKey && localStorage.removeItem(redirectKey);
 
         if (redirectKey && redirectPath) {
-	    let redirectUrl = new URL(keepWebServiceUrl);
-	    // encodeURI will not touch characters such as # ? that may be
-	    // delimiter in overall URL syntax
-	    // Setting pathname attribute will in effect encode # and ?
-	    // while leaving others minimally disturbed (useful for debugging
-	    // and avoids excessive percent-encoding)
-	    redirectUrl.pathname = encodeURI(redirectPath);
-	    redirectUrl.searchParams.set("api_token", token);
+            let redirectUrl = new URL(keepWebServiceUrl);
+            // encodeURI will not touch characters such as # ? that may be
+            // delimiter in overall URL syntax
+            // Setting pathname attribute will in effect encode # and ?
+            // while leaving others minimally disturbed (useful for debugging
+            // and avoids excessive percent-encoding)
+            redirectUrl.pathname = encodeURI(redirectPath);
+            redirectUrl.searchParams.set("api_token", token);
             let u = redirectUrl.href;
             if (redirectKey === REDIRECT_TO_PREVIEW_KEY) {
                 u = getInlineFileUrl(u, keepWebServiceUrl, keepWebInlineServiceUrl);
             }
-            window.location.href = u;
+            if (u) {
+                window.location.href = u;
+            }
         }
     }
 };

--- a/services/workbench2/src/views-components/context-menu/actions/helpers.test.ts
+++ b/services/workbench2/src/views-components/context-menu/actions/helpers.test.ts
@@ -25,7 +25,7 @@ describe('helpers', () => {
             const result = getCollectionItemClipboardUrl(url);
 
             // then
-            expect(result).toBe('http://localhost?redirectToDownload=https://example.com/c=zzzzz-4zz18-0123456789abcde/LIMS/1.html');
+            expect(result).toBe('http://localhost/?redirectToDownload=https%3A//example.com/c=zzzzz-4zz18-0123456789abcde/LIMS/1.html');
         });
     });
 


### PR DESCRIPTION
keep-web: When sending an unauthenticated browser client to a redirect to Wb2, encode the target URL path in the query part of the redirection URL in the `Location` header. This avoids possible corrupted header and confused client.

Workbench2:

- In redirection handler, more robust handling of the input target-path passed by the URL query part.
- In the "copy link to clipboard" action in the files panel of a collection view, when creating the URL for clipboard, better emulate the server-generated redirect URL (see above).

Overall, when working with redirects (either generating redirect URLs or handling them on the client side), we're better prepared for paths that may contain special characters.