### PR TITLE
376: Support for upstream cwltool `INTERNAL_VERSION` v1.3.0-dev1

### DIFF
--- a/sdk/cwl/arvados_cwl/__init__.py
+++ b/sdk/cwl/arvados_cwl/__init__.py
@@ -14,6 +14,8 @@ import os
 import sys
 import re
 
+from packaging.version import Version
+
 from schema_salad.sourceline import SourceLine
 import schema_salad.validate as validate
 import cwltool.main
@@ -22,6 +24,7 @@ import cwltool.process
 import cwltool.argparser
 from cwltool.errors import WorkflowException
 from cwltool.process import shortname, UnsupportedRequirement, use_custom_schema
+from cwltool.update import INTERNAL_VERSION
 from cwltool.utils import adjustFileObjs, adjustDirObjs, get_listing
 
 import arvados
@@ -294,10 +297,24 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
 def add_arv_hints():
     cwltool.command_line_tool.ACCEPTLIST_EN_RELAXED_RE = re.compile(r".*")
     cwltool.command_line_tool.ACCEPTLIST_RE = cwltool.command_line_tool.ACCEPTLIST_EN_RELAXED_RE
-    supported_versions = ["v1.0", "v1.1", "v1.2"]
-    for s in supported_versions:
-        customschema = importlib.resources.read_text(__name__, f'arv-cwl-schema-{s}.yml', encoding='utf-8')
-        use_custom_schema(s, "http://arvados.org/cwl", customschema)
+    supported_versions = ["v1.0", "v1.1", "v1.2"]  # Keep this list sorted.
+    custom_schemas = {}
+    for v in supported_versions:
+        customschema = importlib.resources.read_text(
+            __name__, f'arv-cwl-schema-{v}.yml', encoding='utf-8'
+        )
+        custom_schemas[v] = customschema
+        use_custom_schema(v, "http://arvados.org/cwl", customschema)
+
+    # For the case when our supported versions lag behind cwltool internal
+    # version.
+    arv_latest = supported_versions[-1]
+    if Version(INTERNAL_VERSION) > Version(arv_latest):
+        use_custom_schema(
+            INTERNAL_VERSION,
+            "http://arvados.org/cwl", custom_schemas[arv_latest]
+        )
+
     cwltool.process.supportedProcessRequirements.extend([
         "http://arvados.org/cwl#RunInSingleContainer",
         "http://arvados.org/cwl#OutputDirType",

--- a/sdk/cwl/setup.py
+++ b/sdk/cwl/setup.py
@@ -14,9 +14,10 @@ setuptools.setup(
     cmdclass=arvados_version['CMDCLASS'],
     install_requires=[
         *arv_mod.iter_dependencies(version=version),
-        'cwltool == 3.1.20240508115724',
-        'schema-salad == 8.5.20240503091721',
+        'cwltool == 3.2.20260413085819',
+        'schema-salad == 8.9.20260417192335',
         'ciso8601 >= 2.0.0',
+        'packaging',
     ],
     version=version,
 )

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -87,10 +87,10 @@ setuptools.setup(
         'google-auth',
         'httplib2 >= 0.9.2',
         'pycurl >= 7.19.5.1',
-        # As of 636a597c, sdk/cwl depends on cwltool == 3.1.20240508115724,
+        # As of 417bbed3, sdk/cwl depends on cwltool == 3.2.20260413085819,
         # which also has the following ruamel.yaml dependency; see
-        # https://github.com/common-workflow-language/cwltool/blob/3.1.20240508115724/setup.py#L127
-        'ruamel.yaml >= 0.16, < 0.19',
+        # https://github.com/common-workflow-language/cwltool/blob/3.2.20260413085819/setup.py#L153
+        'ruamel.yaml >= 0.16, < 0.20',
         'websockets >= 11.0',
     ],
 )


### PR DESCRIPTION
`376-fix-support-for-cwl-internal-version` @ a01517a257f3a1d37c4a2a57f3d4295220330e8d

https://ci.arvados.org/job/developer-run-tests/5145/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * When the CWL versions we support lag behind the so-called `INTERNAL_VERSION` of `cwltool`, re-use the latest CWL extension schema we support for that version.
  * This allows us to bump the dependency versions of `cwltool` and `schema_salad` in a-c-r, therefore clearing a blocker for supporting Python versions 3.13 or 3.14.
  * To be sure we're comparing the version strings correctly while not reinventing the wheel, we use `packaging.version.Version`, which pulls in the dependency on `packaging`.
  * Also sync the `ruamel.yaml` version pin in the Python SDK with the `cwltool` dependency.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * This allows the sdk/cwl unit tests and integration tests to pass. For more (e.g. OOM tests), see discussion here https://github.com/arvados/arvados/issues/376#issuecomment-5197454808
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_ (the change is largely under-the-hood; eventually we'll update the docs for Python versions supported)
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * Most likely not impacted.
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _Yes_

Closes #376 .