### PR TITLE
487: Bump `cwltest` version; fix CWL integration-test false positives

### DIFF
--- a/build/requirements.tests.txt
+++ b/build/requirements.tests.txt
@@ -20,7 +20,7 @@ pytest
 
 ### Requirements for individual tests
 # Run by CWL integration tests
-cwltest >= 2.5.20241122133319, < 3.0
+cwltest >= 2.7.20260814074913, < 3.0
 
 # Required to build Python SDK documentation
 pdoc ~= 16.0


### PR DESCRIPTION
`487-bump-cwltest-version` @ 6798355f12c690d7954eff037fd710cfacbf1595

https://ci.arvados.org/job/developer-run-tests/5148/
https://ci.arvados.org/job/arvados-cwl-conformance-tests/2162/ (❌ this has failed already as I am typing this PR, possibly due to misconfiguration)

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * The failing CWL integration/conformance tests on Python 3.12+ was a false positive.
  * The issue has been fixed in upstream `cwltest` [2.7.20260814074913](https://github.com/common-workflow-language/cwltest/releases/tag/2.7.20260814074913)
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * On a local system, manually tested with `test sdk/cwl -m integration` under Python 3.12.14 and 3.14.7
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * _N/A_
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _N/A_

Closes #487.