### PR TITLE
493: Fix spurious CWL test failure due to "dirname" field on Directory.

### DIFF
--- a/sdk/cwl/setup.py
+++ b/sdk/cwl/setup.py
@@ -14,8 +14,8 @@ setuptools.setup(
     cmdclass=arvados_version['CMDCLASS'],
     install_requires=[
         *arv_mod.iter_dependencies(version=version),
-        'cwltool == 3.2.20260413085819',
-        'schema-salad == 8.9.20260417192335',
+        'cwltool == 3.2.20260720092025',
+        'schema-salad == 8.10.20260814121804',
         'ciso8601 >= 2.0.0',
         'packaging',
     ],

--- a/sdk/cwl/tests/test_container.py
+++ b/sdk/cwl/tests/test_container.py
@@ -875,7 +875,6 @@ class TestContainer(unittest.TestCase):
                         "p1": {
                             "basename": "99999999999999999999999999999994+44",
                             "class": "Directory",
-                            "dirname": "/keep",
                             "http://arvados.org/cwl#collectionUUID": "zzzzz-4zz18-zzzzzzzzzzzzzzz",
                             "listing": [
                                 {


### PR DESCRIPTION
`493-bump-cwltool` @ 42ceb18d4e2a50f9ed647eefe5e206c560d9b995

https://ci.arvados.org/job/developer-run-tests/5150/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Bump `cwltool` and `schema-salad` dependency version pins.
  * In the offending test, remove the expected `"dirname"` field on the `Directory` object.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * CWL tests passed; CWL integration tests also passed on local runs.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_
* Documentation has been updated.
  * _N/A_
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * _N/A_
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _Yes_

Closes #493.