### PR TITLE
383: Ansible installer changes to prepare for Salt migration

### DIFF
--- a/tools/ansible/examples/full-cluster-inventory.yml
+++ b/tools/ansible/examples/full-cluster-inventory.yml
@@ -77,7 +77,7 @@ all:
     #arvados_nginx_internal_networks:
     #  "10.0.0.0/8": true
     #  "172.16.0.0/12": true
-    #  "192.168.0.0/16: true
+    #  "192.168.0.0/16": true
 
     # By default, this playbook installs PostgreSQL packages from your
     # distribution. If you prefer to install a specific version from

--- a/tools/ansible/roles/arvados_aws_secret/tasks/main.yml
+++ b/tools/ansible/roles/arvados_aws_secret/tasks/main.yml
@@ -26,10 +26,3 @@
     owner: root
     group: root
     mode: 0644
-
-- name: Add symlink from password_secret_connector service to arvados_aws_secret
-  become: yes
-  ansible.builtin.file:
-    state: link
-    src: /etc/systemd/system/arvados_aws_secret.service
-    dest: /etc/systemd/system/password_secret_connector.service

--- a/tools/ansible/roles/arvados_nginx_frontend/defaults/main.yml
+++ b/tools/ansible/roles/arvados_nginx_frontend/defaults/main.yml
@@ -2,6 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# If you set arvados_nginx_log_basename, the nginx frontend will have
+# access_log and error_log directives based on it. If those don't meet your
+# needs, set it to a falsy value and add your own directives to
+# arvados_nginx_server_config.
+arvados_nginx_log_basename: "arvados-{{ arvados_nginx_service_key }}"
+
 # arvados_nginx_proxy_config is an nginx configuration block that will be used
 # for all proxy front-ends. The default has standard configuration suitable for
 # all Arvados services.

--- a/tools/ansible/roles/arvados_nginx_frontend/templates/arvados-nginx-site.conf.j2
+++ b/tools/ansible/roles/arvados_nginx_frontend/templates/arvados-nginx-site.conf.j2
@@ -24,6 +24,10 @@ server {
 {% if tls_source.key.aws_secret is defined %}
   ssl_password_file    /run/arvados/{{ tls_source.key.aws_secret }};
 {% endif %}
+{% if arvados_nginx_log_basename is truthy %}
+  access_log  /var/log/nginx/{{ arvados_nginx_log_basename }}.access.log  combined;
+  error_log   /var/log/nginx/{{ arvados_nginx_log_basename }}.error.log;
+{% endif %}
 
   {{ arvados_nginx_server_config|indent(2) }}
 {% block server_config %}


### PR DESCRIPTION
383-salt-nginx-config-in-ansible @ f63d96e5fcd99431e6c189653f205e25af3a45d1 - https://ci.arvados.org/view/Developer/job/test-provision-ansible/38/ (ubunt2604 failure is because of #488)

This branch makes a couple minor changes to the Ansible installer to better support installs migrating from Salt. In particular those clusters can set the new `arvados_nginx_log_basename` to keep logging to the same locations they have been so far.

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * This doesn't complete the ticket but the changes are self-contained and useful immediately.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * N/A
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * See above, also updated my single-node cluster with these changes and saw the desired effect.
* Tested code incorporates recent main branch changes.
  * Yes
* New or changed UI/UX and has gotten feedback from stakeholders.
  * N/A
* Documentation has been updated.
  * The new default has an explanatory comment, same as many others.
* Behaves appropriately at the intended scale (describe intended scale).
  * No change
* Considered backwards and forwards compatibility issues between client and server.
  * N/A
* Follows our [coding standards](https://dev.arvados.org/projects/arvados/wiki/Coding_Standards) and [GUI style guidelines](https://dev.arvados.org/projects/arvados/wiki/Coding_Standards#GUI-Design-Guidelines-Workbench-2).
  * N/A
