### PR TITLE
379: Separate nginx front-end setup in Ansible installer

### DIFF
--- a/doc/admin/upgrading.html.textile.liquid
+++ b/doc/admin/upgrading.html.textile.liquid
@@ -52,6 +52,10 @@ These conditions can arise in the following cases:
 
 To disable the new behavior and ensure that each container runs on a dedicated instance even in the above cases, set the new configuration entry @Containers.MaxRunningContainersPerInstance@ to @1@.
 
+h3. Ansible installer manages new host groups
+
+In order to support load balanced multi-node installs, the Ansible installer manages new host groups @arvados_controller_nginx@, @arvados_keepproxy_nginx@, @arvados_keep_web_nginx@, and @arvados_websocket_nginx@ separately from their original service groups. You should add these groups to your Ansible inventory(ies) before you upgrade to Arvados 3.3. The example inventories in the @tools/ansible/examples/@ directory describe how to define these groups for different use cases.
+
 h3. CLI SDK obsoleted by Python SDK
 
 As of Arvados 3.3.0, we no longer publish the @arvados-cli@ gem that provided the @arv@ command-line client for Arvados. The "@arv@ tool":{{ site.baseurl }}/sdk/python/arv-cli.html is now included with the "Python SDK":{{ site.baseurl }}/sdk/python/sdk-python.html. The @arv@ tool already required the Python SDK to be installed for full functionality, so this change simply eliminates the need to install a separate gem.

--- a/tools/ansible/examples/full-cluster-inventory.yml
+++ b/tools/ansible/examples/full-cluster-inventory.yml
@@ -148,6 +148,34 @@ arvados_workbench:
     workbench.arvados.example:
 
 
+### Host groups for Arvados web front-ends ###
+# The Arvados servers for API controller, websockets, keepproxy, and
+# keep-web/WebDAV expect to run behind a production web front-end.
+# The following groups deploy nginx to do that.
+# This example configuration shows the simple case of deploying nginx on the
+# same host as the Arvados service. You can deploy these groups to different
+# host(s) if desired. Note that *all* nginx front-ends will proxy *all* the
+# corresponding back-end services for load balancing via the InternalURLs
+# in your Arvados cluster configuration.
+# You can make these groups empty if you plan to configure a different
+# web front-end such as AWS ELB.
+arvados_controller_nginx:
+  children:
+    arvados_controller:
+
+arvados_websocket_nginx:
+  children:
+    arvados_websocket:
+
+arvados_keepproxy_nginx:
+  children:
+    arvados_keepproxy:
+
+arvados_keep_web_nginx:
+  children:
+    arvados_keep_web:
+
+
 ### Host groups for Arvados dispatchers ###
 # A complete Arvados cluster must deploy at least one dispatcher, but
 # different clusters run different dispatchers. Uncomment and define the

--- a/tools/ansible/examples/simple-cluster-inventory.yml
+++ b/tools/ansible/examples/simple-cluster-inventory.yml
@@ -79,7 +79,15 @@ arvados_api:
 ### Arvados services ###
 # The rest of the inventory defines the Arvados services to run on the
 # cluster host. You should not need to change anything from here on.
+arvados_controller_nginx:
+  children:
+    arvados_cluster_host:
+
 arvados_controller:
+  children:
+    arvados_cluster_host:
+
+arvados_websocket_nginx:
   children:
     arvados_cluster_host:
 
@@ -95,7 +103,15 @@ arvados_keepbalance:
   children:
     arvados_cluster_host:
 
+arvados_keepproxy_nginx:
+  children:
+    arvados_cluster_host:
+
 arvados_keepproxy:
+  children:
+    arvados_cluster_host:
+
+arvados_keep_web_nginx:
   children:
     arvados_cluster_host:
 

--- a/tools/ansible/install-arvados-cluster.yml
+++ b/tools/ansible/install-arvados-cluster.yml
@@ -48,12 +48,30 @@
     - ansible.builtin.include_role:
         name: arvados_api
 
+- name: Set up API controller nginx front-end
+  hosts: arvados_controller_nginx
+  serial: 1
+  tasks:
+    - ansible.builtin.include_role:
+        name: arvados_nginx_frontend
+      vars:
+        arvados_nginx_service_key: Controller
+
 - name: Set up API controller(s)
   hosts: arvados_controller
   serial: 1
   tasks:
     - ansible.builtin.include_role:
         name: arvados_controller
+
+- name: Set up WebSocket server nginx front-end
+  hosts: arvados_websocket_nginx
+  serial: 1
+  tasks:
+    - ansible.builtin.include_role:
+        name: arvados_nginx_frontend
+      vars:
+        arvados_nginx_service_key: Websocket
 
 - name: Set up WebSocket server
   hosts: arvados_websocket
@@ -76,12 +94,30 @@
     - ansible.builtin.include_role:
         name: arvados_keepbalance
 
+- name: Set up keepproxy nginx front-end
+  hosts: arvados_keepproxy_nginx
+  serial: 1
+  tasks:
+    - ansible.builtin.include_role:
+        name: arvados_nginx_frontend
+      vars:
+        arvados_nginx_service_key: Keepproxy
+
 - name: Set up keepproxy(ies)
   hosts: arvados_keepproxy
   serial: 1
   tasks:
     - ansible.builtin.include_role:
         name: arvados_keepproxy
+
+- name: Set up keep-web nginx front-end
+  hosts: arvados_keep_web_nginx
+  serial: 1
+  tasks:
+    - ansible.builtin.include_role:
+        name: arvados_nginx_frontend
+      vars:
+        arvados_nginx_service_key: WebDAV
 
 - name: Set up keep-web(s)
   hosts: arvados_keep_web

--- a/tools/ansible/roles/arvados_controller/meta/main.yml
+++ b/tools/ansible/roles/arvados_controller/meta/main.yml
@@ -5,6 +5,3 @@
 dependencies:
   - role: arvados_apt
   - role: arvados_service
-  - role: arvados_nginx_frontend
-    vars:
-      arvados_nginx_service_key: Controller

--- a/tools/ansible/roles/arvados_keep_web/meta/main.yml
+++ b/tools/ansible/roles/arvados_keep_web/meta/main.yml
@@ -5,6 +5,3 @@
 dependencies:
   - role: arvados_apt
   - role: arvados_service
-  - role: arvados_nginx_frontend
-    vars:
-      arvados_nginx_service_key: WebDAV

--- a/tools/ansible/roles/arvados_keepproxy/meta/main.yml
+++ b/tools/ansible/roles/arvados_keepproxy/meta/main.yml
@@ -5,6 +5,3 @@
 dependencies:
   - role: arvados_apt
   - role: arvados_service
-  - role: arvados_nginx_frontend
-    vars:
-      arvados_nginx_service_key: Keepproxy

--- a/tools/ansible/roles/arvados_websocket/meta/main.yml
+++ b/tools/ansible/roles/arvados_websocket/meta/main.yml
@@ -5,6 +5,3 @@
 dependencies:
   - role: arvados_apt
   - role: arvados_service
-  - role: arvados_nginx_frontend
-    vars:
-      arvados_nginx_service_key: Websocket


### PR DESCRIPTION
379-ansible-separate-nginx-frontends @ e1c83408130762d27d669242a3aa1e13fd015e0a - https://ci.arvados.org/job/test-provision-ansible/39/ (ubuntu2604 failing because of Docker 29)

This extends the Ansible installer to support load balanced nginx front-ends by adding new groups to deploy nginx separately from Arvados services. This continues to support the simple case of one nginx front-end on the same host as an Arvados service we had before, including single-node installs.

I spent a lot of time thinking about whether I needed some kind of inventory validation before deploying the nginx front-end this way. I eventually decided the answer was no. This version works to support all the deployments we support today: same-host installs and single load-balanced installs. If you give it a different configuration, it will do something functional. In particular, if you deploy the nginx front-end to multiple controller nodes, it will deploy multiple load-balanced nginx front-ends to those nodes. That may not be what the admin *wants*, but I would rather have the use case in front of us and figure out how to address it than try to anticipate a need.

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Implements the whole narrow scope as recently commented in the ticket. Does not have any code to mark backends down, but I do not believe any user requires that.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * N/A
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * In addition to test-provision, upgraded my own single-node cluster with this. That also worked as it should.
* Tested code incorporates recent main branch changes.
  * Yes
* New or changed UI/UX and has gotten feedback from stakeholders.
  * N/A
* Documentation has been updated.
  * Upgrade note and both example inventories have been updated.
* Behaves appropriately at the intended scale (describe intended scale).
  * No change
* Considered backwards and forwards compatibility issues between client and server.
  * N/A
* Follows our [coding standards](https://dev.arvados.org/projects/arvados/wiki/Coding_Standards) and [GUI style guidelines](https://dev.arvados.org/projects/arvados/wiki/Coding_Standards#GUI-Design-Guidelines-Workbench-2).
  * N/A