### PR TITLE
Add logrotate rule for RailsAPI server in Ansible

### DIFF
--- a/tools/ansible/roles/arvados_api/defaults/main.yml
+++ b/tools/ansible/roles/arvados_api/defaults/main.yml
@@ -2,5 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# logrotate rotation and compression options for RailsAPI server logs. You
+# can override this to set your own directives to match your log retention
+# policy. The configuration file includes other directives required for
+# logrotate to play well with Passenger.
+arvados_api_logrotate: |
+  daily
+  rotate 30
+  compress
+  nodelaycompress
+
 arvados_api_max_pool_size: "{{ ansible_processor_nproc | int }}"
 arvados_api_max_request_queue_size: "{{ arvados_api_max_pool_size | int * 2 + 1 }}"

--- a/tools/ansible/roles/arvados_api/tasks/main.yml
+++ b/tools/ansible/roles/arvados_api/tasks/main.yml
@@ -11,7 +11,17 @@
   become: yes
   ansible.builtin.apt:
     name:
+      - logrotate
       - "postgresql-client{{ arvados_postgresql_suffix }}"
+
+- name: Install Arvados API server logrotate configuration
+  become: yes
+  ansible.builtin.template:
+    src: logrotate.conf.j2
+    dest: /etc/logrotate.d/arvados-api
+    owner: root
+    group: root
+    mode: 0755
 
 - name: Install arvados-api-server
   become: yes

--- a/tools/ansible/roles/arvados_api/tasks/main.yml
+++ b/tools/ansible/roles/arvados_api/tasks/main.yml
@@ -5,7 +5,9 @@
 # Install the RailsAPI server and configure it to match the cluster
 # configuration.
 
-- name: Install PostgreSQL client package
+# We want to install postgresql-client *before* arvados-api-server to make
+# sure gems see and use our desired version.
+- name: Install API server dependencies
   become: yes
   ansible.builtin.apt:
     name:

--- a/tools/ansible/roles/arvados_api/templates/logrotate.conf.j2
+++ b/tools/ansible/roles/arvados_api/templates/logrotate.conf.j2
@@ -1,0 +1,16 @@
+### This file is managed by Ansible ###
+{# Copyright (C) The Arvados Authors. All rights reserved.
+ #
+ # SPDX-License-Identifier: Apache-2.0
+ #}
+
+/var/www/arvados-api/shared/log/*.log
+{
+  {{ arvados_api_logrotate|indent(2) }}
+  missingok
+  copytruncate
+  sharedscripts
+  postrotate
+    systemctl try-reload-or-restart arvados-railsapi.service
+  endscript
+}


### PR DESCRIPTION
501-ansible-railsapi-logrotate @ 4a93ebd7e256df9ef0617d362bdee902fe428b5a - <https://ci.arvados.org/job/test-provision-ansible/40/>

This does what the Salt installer does except the default retention period is 30 days vs. Salt's 365. 30 is more suitable for smaller clusters which tend to do less configuration. Clusters migrating from Salt can use the new setting to retain their current behavior.

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Yes
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * N/A
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * See above, also ran it on my local single-node cluster.
* Tested code incorporates recent main branch changes.
  * Yes
* New or changed UI/UX and has gotten feedback from stakeholders.
  * N/A
* Documentation has been updated.
  * Yes (comment for the new setting as usual)
* Behaves appropriately at the intended scale (describe intended scale).
  * See notes above
* Considered backwards and forwards compatibility issues between client and server.
  * Ditto
* Follows our [coding standards](https://dev.arvados.org/projects/arvados/wiki/Coding_Standards) and [GUI style guidelines](https://dev.arvados.org/projects/arvados/wiki/Coding_Standards#GUI-Design-Guidelines-Workbench-2).
  * N/A
