### PR TITLE
Upgrade to Cypress 14

### DIFF
--- a/services/workbench2/cypress.config.ts
+++ b/services/workbench2/cypress.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
   },
 
   component: {
+    justInTimeCompile: false,
     devServer: {
       framework: "react",
       bundler: "webpack",

--- a/services/workbench2/cypress/support/component.ts
+++ b/services/workbench2/cypress/support/component.ts
@@ -18,12 +18,12 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-import { mount } from 'cypress/react'
+import { mount } from '@cypress/react';
 
 // Augment the Cypress namespace to include type definitions for
 // your custom command.
@@ -37,7 +37,7 @@ import { mount } from 'cypress/react'
 //   }
 // }
 
-Cypress.Commands.add('mount', mount)
+Cypress.Commands.add('mount', mount);
 
 /*
     The following is a workaraound for Arvados Issue #22483 which is known and persists in Cypress v14+:

--- a/services/workbench2/cypress/support/e2e.js
+++ b/services/workbench2/cypress/support/e2e.js
@@ -18,7 +18,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
+import './commands';
 
 // Comment out to turn off fail-fast behavior for all tests
 // DO NOT FORGET TO UNCOMMENT THIS LINE BEFORE COMMITTING

--- a/services/workbench2/package.json
+++ b/services/workbench2/package.json
@@ -141,6 +141,7 @@
     "watch-css": "npm run build-css && node-sass src/ -o src/ --watch --recursive"
   },
   "devDependencies": {
+    "@cypress/react": "^8",
     "@sinonjs/fake-timers": "^10.3.0",
     "@types/classnames": "2.2.6",
     "@types/is-image": "3.0.0",
@@ -155,8 +156,8 @@
     "@types/sinon": "7.5",
     "@types/uuid": "3.4.4",
     "axios-mock-adapter": "^2.1.0",
-    "cypress": "^13.6.6",
-    "cypress-wait-until": "^3.0.1",
+    "cypress": "^14.0.0",
+    "cypress-wait-until": "^3.0.2",
     "node-sass": "^9.0.0",
     "redux-devtools": "^3.7.0",
     "redux-mock-store": "1.5.4",

--- a/services/workbench2/yarn.lock
+++ b/services/workbench2/yarn.lock
@@ -1613,13 +1613,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@colors/colors@npm:1.5.0":
-  version: 1.5.0
-  resolution: "@colors/colors@npm:1.5.0"
-  checksum: d64d5260bed1d5012ae3fc617d38d1afc0329fec05342f4e6b838f46998855ba56e0a73833f4a80fa8378c84810da254f76a8a19c39d038260dc06dc4e007425
-  languageName: node
-  linkType: hard
-
 "@coreui/coreui@npm:^4.3.2":
   version: 4.3.2
   resolution: "@coreui/coreui@npm:4.3.2"
@@ -1815,7 +1808,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cypress/request@npm:^3.0.6":
+"@cypress/react@npm:^8":
+  version: 8.0.2
+  resolution: "@cypress/react@npm:8.0.2"
+  peerDependencies:
+    "@types/react": ^16.9.16 || ^17.0.0
+    cypress: "*"
+    react: ^=16.x || ^=17.x
+    react-dom: ^=16.x || ^=17.x
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: ac435c81d7e60934728411d0de4634cf76523705780b835f4eb1ffa4dc1a8c00302f6ce4b7e6cde27265251f37467f9fce950de19d69142c3771c3ac87ad122b
+  languageName: node
+  linkType: hard
+
+"@cypress/request@npm:^3.0.9":
   version: 3.0.10
   resolution: "@cypress/request@npm:3.0.10"
   dependencies:
@@ -4438,6 +4446,7 @@ __metadata:
     "@babel/runtime-corejs2": ^7.0.0
     "@coreui/coreui": ^4.3.2
     "@coreui/react": ^4.11.0
+    "@cypress/react": ^8
     "@date-io/date-fns": 1
     "@emotion/react": ^11.11.4
     "@emotion/styled": ^11.11.5
@@ -4493,10 +4502,10 @@ __metadata:
     css-loader: ^6.5.1
     css-minimizer-webpack-plugin: ^3.2.0
     cwlts: 1.15.29
-    cypress: ^13.6.6
+    cypress: ^14.0.0
     cypress-fail-fast: ^7.1.1
     cypress-plugin-tab: ^1.0.5
-    cypress-wait-until: ^3.0.1
+    cypress-wait-until: ^3.0.2
     date-fns: ^2.28.0
     debounce: 1.2.0
     dompurify: ^3.4.12
@@ -5337,7 +5346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.0.0":
+"ci-info@npm:^4.1.0":
   version: 4.4.0
   resolution: "ci-info@npm:4.4.0"
   checksum: 3418954c9ca192d4ab7f88637835f8463a327dfcb1d9fdd2434f0aba2715d8b2b0e79fd1a4297cc4a35efc5728f8fd74f3b31cb741c948469a4c07dfe8df3675
@@ -5390,16 +5399,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-table3@npm:~0.6.1":
-  version: 0.6.3
-  resolution: "cli-table3@npm:0.6.3"
+"cli-table3@npm:0.6.1":
+  version: 0.6.1
+  resolution: "cli-table3@npm:0.6.1"
   dependencies:
-    "@colors/colors": 1.5.0
+    colors: 1.4.0
     string-width: ^4.2.0
   dependenciesMeta:
-    "@colors/colors":
+    colors:
       optional: true
-  checksum: 09897f68467973f827c04e7eaadf13b55f8aec49ecd6647cc276386ea660059322e2dd8020a8b6b84d422dbdd619597046fa89cbbbdc95b2cea149a2df7c096c
+  checksum: 956e175f8eb019c26465b9f1e51121c08d8978e2aab04be7f8520ea8a4e67906fcbd8516dfb77e386ae3730ef0281aa21a65613dffbfa3d62969263252bd25a9
   languageName: node
   linkType: hard
 
@@ -5483,6 +5492,13 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 0c016fea2b91b733eb9f4bcdb580018f52c0bc0979443dad930e5037a968237ac53d9beb98e218d2e9235834f8eebce7f8e080422d6194e957454255bde71d3d
+  languageName: node
+  linkType: hard
+
+"colors@npm:1.4.0":
+  version: 1.4.0
+  resolution: "colors@npm:1.4.0"
+  checksum: 98aa2c2418ad87dedf25d781be69dc5fc5908e279d9d30c34d8b702e586a0474605b3a189511482b9d5ed0d20c867515d22749537f7bc546256c6014f3ebdcec
   languageName: node
   linkType: hard
 
@@ -6111,18 +6127,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cypress-wait-until@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "cypress-wait-until@npm:3.0.1"
-  checksum: 487626011bf260b2e6cda68f1ced6cb4bb09013e479cd12681eeb577f788d5fd46c95040add9849d4ee1109c8e553330aadb42f2a252e8656bb8c3dbf776a087
+"cypress-wait-until@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "cypress-wait-until@npm:3.0.2"
+  checksum: 39bb994b9fefae8d607973c86ddefe34a72ec9ebb404749e0edb0a5e6d174f85671d83d5af58067c6fc55d40abf2b40cfccd7d31f51d226479d8c681abc9e876
   languageName: node
   linkType: hard
 
-"cypress@npm:^13.6.6":
-  version: 13.17.0
-  resolution: "cypress@npm:13.17.0"
+"cypress@npm:^14.0.0":
+  version: 14.5.4
+  resolution: "cypress@npm:14.5.4"
   dependencies:
-    "@cypress/request": ^3.0.6
+    "@cypress/request": ^3.0.9
     "@cypress/xvfb": ^1.2.4
     "@types/sinonjs__fake-timers": 8.1.1
     "@types/sizzle": ^2.3.2
@@ -6133,9 +6149,9 @@ __metadata:
     cachedir: ^2.3.0
     chalk: ^4.1.0
     check-more-types: ^2.24.0
-    ci-info: ^4.0.0
+    ci-info: ^4.1.0
     cli-cursor: ^3.1.0
-    cli-table3: ~0.6.1
+    cli-table3: 0.6.1
     commander: ^6.2.1
     common-tags: ^1.8.0
     dayjs: ^1.10.4
@@ -6148,6 +6164,7 @@ __metadata:
     figures: ^3.2.0
     fs-extra: ^9.1.0
     getos: ^3.2.1
+    hasha: 5.2.2
     is-installed-globally: ~0.4.0
     lazy-ass: ^1.6.0
     listr2: ^3.8.3
@@ -6159,7 +6176,7 @@ __metadata:
     process: ^0.11.10
     proxy-from-env: 1.0.0
     request-progress: ^3.0.0
-    semver: ^7.5.3
+    semver: ^7.7.1
     supports-color: ^8.1.1
     tmp: ~0.2.3
     tree-kill: 1.2.2
@@ -6167,7 +6184,7 @@ __metadata:
     yauzl: ^2.10.0
   bin:
     cypress: bin/cypress
-  checksum: c1d87358e8b92e19e3bf5246a8787dcdd5083e27fa7b816d26c28b4678ecd87b5b3b8661fb812bc993845ca30a482d3f18837af1ac6d9e142e41049dccbc51e0
+  checksum: 5fe95e88a6af1a454021a00490e051e658254744d14f0f51ecadb98ad2a37097f4774163423384a5a7d847496e5bb5b46cdf9c68007a86530659758edf1a9405
   languageName: node
   linkType: hard
 
@@ -8437,6 +8454,16 @@ __metadata:
   version: 2.0.1
   resolution: "has-unicode@npm:2.0.1"
   checksum: 1eab07a7436512db0be40a710b29b5dc21fa04880b7f63c9980b706683127e3c1b57cb80ea96d47991bdae2dfe479604f6a1ba410106ee1046a41d1bd0814400
+  languageName: node
+  linkType: hard
+
+"hasha@npm:5.2.2":
+  version: 5.2.2
+  resolution: "hasha@npm:5.2.2"
+  dependencies:
+    is-stream: ^2.0.0
+    type-fest: ^0.8.0
+  checksum: 06cc474bed246761ff61c19d629977eb5f53fa817be4313a255a64ae0f433e831a29e83acb6555e3f4592b348497596f1d1653751008dda4f21c9c21ca60ac5a
   languageName: node
   linkType: hard
 
@@ -13601,12 +13628,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
-  version: 7.6.2
-  resolution: "semver@npm:7.6.2"
+"semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.4, semver@npm:^7.7.1":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
   bin:
     semver: bin/semver.js
-  checksum: 40f6a95101e8d854357a644da1b8dd9d93ce786d5c6a77227bc69dbb17bea83d0d1d1d7c4cd5920a6df909f48e8bd8a5909869535007f90278289f2451d0292d
+  checksum: 0c580f17e88e2b45806dc5cf3d824f719c946999d3554bf30307c2b68b3300ab3c8bfcd84d8f489b93b4cbb5362f5fc8de4d2858954f18d834253c4450fc9f6b
   languageName: node
   linkType: hard
 
@@ -15032,7 +15059,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^0.8.1":
+"type-fest@npm:^0.8.0, type-fest@npm:^0.8.1":
   version: 0.8.1
   resolution: "type-fest@npm:0.8.1"
   checksum: d61c4b2eba24009033ae4500d7d818a94fd6d1b481a8111612ee141400d5f1db46f199c014766b9fa9b31a6a7374d96fc748c6d688a78a3ce5a33123839becb7


### PR DESCRIPTION
`507-upgrade-to-cypress-14` @ 9e010b398a2c824774bba902e21ee7d07709a82f

https://ci.arvados.org/job/developer-run-tests/5161/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * Follow [Cypress migration guide](https://docs.cypress.io/app/references/migration-guide#Migrating-to-Cypress-140) to install additional dev dependencies with `yarn` and upgrade `cypress` version.
  * Disable `justInTimeCompile` config option because the option causes unit tests to fail. By disabling JIT for component testing, we restore the old behavior under Cypress 13.
  * Update the Cypress plugin we use.
  * Minor fixes for our own support files under `cypress/support`.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * In addition to the Jenkins test run, the following manual tests were performed locally:
    * Run `make interactive-tests-in-docker` in the Workbench project directory, to build the Docker image and volume, and run Cypress interactively in Debian 13 GNOME environment (with Electron 130).
    * Run headless WB unit and integration tests locally.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * Well, _we_ are the stakeholders; this is also part of the effort to make Arvados development more accessible to community members.
* Documentation has been updated.
  * _N/A_
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * _N/A_
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _N/A_

Closes #507.