### PR TITLE
514: WB: fix favorites e2e tests

### DIFF
--- a/services/workbench2/cypress/e2e/favorites.cy.js
+++ b/services/workbench2/cypress/e2e/favorites.cy.js
@@ -353,6 +353,15 @@ describe('Favorites-SidePanel tests', function () {
     });
 
     it('restores trashed favorite project to favorites', () => {
+        // The following faved item is not touched; simply used to keep the
+        // favorites dropdown in the sidebar from collapsing once (which
+        // happens if all faved items are gone)
+        cy.createProject({
+            owningUser: adminUser,
+            projectName: `myFavoriteProject0`,
+            addToFavorites: true,
+        });
+
         cy.createProject({
             owningUser: adminUser,
             projectName: `myFavoriteProject1`,
@@ -360,64 +369,77 @@ describe('Favorites-SidePanel tests', function () {
         });
 
         cy.loginAs(adminUser);
-        cy.doSidePanelNavigation('Home Projects');
+        cy.goToPath(`/projects/${adminUser.user.uuid}`);
+
+        // Open the favorite dropdown
+        cy.get('[data-cy=tree-item-toggle-my-favorites]').click();
 
         cy.get('@myFavoriteProject1')
             .then(function (myFavoriteProject1) {
                 // Trash favorited project
                 cy.get('[data-cy=data-table]').contains(myFavoriteProject1.name).rightclick();
                 cy.get('[data-cy=context-menu]').contains('Move to trash').click();
-                cy.waitForDom();
+                // Snackbar assertion as a barrier
+                cy.get("[data-cy=snackbar]").should("contain", "Item trashed");
+
                 // Check removed from favorites
                 cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('not.contain', myFavoriteProject1.name);
+
                 // Untrash favorited project
                 cy.get('[data-cy=side-panel-tree]').contains('Trash').click();
                 cy.get('[data-cy=data-table]').contains(myFavoriteProject1.name).rightclick();
                 cy.get('[data-cy=context-menu]').contains('Restore').click();
-                //navigates to restored project
-                cy.assertDetailsCardTitle(myFavoriteProject1.name);
-                cy.assertBreadcrumbs(["Home Projects", myFavoriteProject1.name]);
+
+                // Snackbar assertion as a barrier
+                cy.get("[data-cy=snackbar]").should("contain", "Item untrashed");
+
                 // Check project restored to favorites
-                cy.wait(1000);
-                // Open favorites
-                cy.get(`[data-cy=tree-item-toggle-my-favorites]`).click();
                 cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('contain', myFavoriteProject1.name);
             });
     });
 
     it('restores trashed favorite collection to favorites', () => {
+        // The following faved item is not touched; simply used to keep the
+        // favorites dropdown in the sidebar from collapsing once (which
+        // happens if all faved items are gone)
+        cy.createProject({
+            owningUser: adminUser,
+            projectName: `myFavoriteProject0`,
+            addToFavorites: true,
+        });
+
+        const collName = `Test favorite collection ${Math.floor(Math.random() * 999999)}`;
         cy.createCollection(adminUser.token, {
             owner_uuid: adminUser.user.uuid,
-            name: `Test favorite collection ${Math.floor(Math.random() * 999999)}`,
-        }).as('testFavoriteCollection');
+            name: collName,
+        });
 
         cy.loginAs(adminUser);
-        cy.getAll('@testFavoriteCollection')
-            .then(function ([testFavoriteCollection]) {
-                cy.get('[data-cy=side-panel-tree]').contains('Home Projects').click().waitForDom();
-                cy.doMPVTabSelect("Data");
-                cy.get('[data-cy=data-table]').contains(testFavoriteCollection.name).rightclick();
-                cy.get('[data-cy=context-menu]').contains('Add to favorites').click();
-                cy.waitForDom()
-                cy.get('[data-cy=data-table]').contains(testFavoriteCollection.name).rightclick();
-                cy.get('[data-cy=context-menu]').contains('Move to trash').click();
-                // Keep the favorites open
-                cy.get('[data-cy=tree-item-toggle-my-favorites]').click({ force: true })
-                cy.wait(1000);
-                // Check removed from favorites
-                cy.get('[data-cy=side-panel-tree]').should('not.contain', testFavoriteCollection.name);
-                // Untrash favorited collection
-                cy.get('[data-cy=side-panel-tree]').contains('Trash').click();
-                // collection might not be on first page
-                cy.get('[data-cy=search-input]').type(testFavoriteCollection.name);
-                cy.waitForDom();
-                cy.get('[data-cy=data-table]').contains(testFavoriteCollection.name).rightclick();
-                cy.get('[data-cy=context-menu]').contains('Restore').click();
-                cy.get('[data-cy=data-table]').should('exist', { timeout: 10000 })
-                cy.assertDataExplorerContains(testFavoriteCollection.name, false);
-                // Check collection restored to favorites
-                cy.wait(1000);
-                cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('contain', testFavoriteCollection.name);
-        });
+        cy.goToPath(`/projects/${adminUser.user.uuid}`);
+        // Open the favorite dropdown
+        cy.get('[data-cy=tree-item-toggle-my-favorites]').click();
+        cy.doMPVTabSelect("Data");
+
+        // Fave
+        cy.get('[data-cy=data-table]').contains(collName).rightclick();
+        cy.get('[data-cy=context-menu]').contains('Add to favorites').click();
+        // Trash
+        cy.get('[data-cy=data-table]').contains(collName).rightclick();
+        cy.get('[data-cy=context-menu]').contains('Move to trash').click();
+        // Snackbar assertion as a barrier
+        cy.get("[data-cy=snackbar]").should("contain", "Item trashed");
+
+        // Check removed from sidebar
+        cy.get('[data-cy=side-panel-tree]').should('not.contain', collName);
+
+        // Untrash favorited collection
+        cy.get('[data-cy=side-panel-tree]').contains('Trash').click();
+        cy.get('[data-cy=data-table]').contains(collName).rightclick();
+        cy.get('[data-cy=context-menu]').contains('Restore').click();
+        // Snackbar assertion as a barrier
+        cy.get("[data-cy=snackbar]").should("contain", "Item untrashed");
+
+        // Check collection restored to favorites
+        cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('contain', collName);
     });
 });

--- a/services/workbench2/cypress/e2e/favorites.cy.js
+++ b/services/workbench2/cypress/e2e/favorites.cy.js
@@ -289,10 +289,12 @@ describe('Favorites-SidePanel tests', function () {
         cy.createProject({
             owningUser: adminUser,
             projectName: `myFavoriteProject1`,
+            addToFavorites: true,
         });
         cy.createProject({
             owningUser: adminUser,
             projectName: `myFavoriteProject2`,
+            addToFavorites: true,
         });
         cy.createProject({
             owningUser: adminUser,
@@ -305,18 +307,10 @@ describe('Favorites-SidePanel tests', function () {
 
         cy.loginAs(adminUser);
         cy.doSidePanelNavigation('Home Projects');
+        cy.doMPVTabSelect("Data");
 
         cy.getAll('@myFavoriteProject1', '@myFavoriteProject2', '@myPublicFavoriteProject1', '@myPublicFavoriteProject2')
         .then(function ([myFavoriteProject1, myFavoriteProject2, myPublicFavoriteProject1, myPublicFavoriteProject2, ]) {
-
-                //add two projects to favorites
-                cy.get('[data-cy=side-panel-tree]').contains(myFavoriteProject1.name).rightclick();
-                cy.contains('Add to favorites').click();
-                cy.get('[data-cy=side-panel-tree]').contains(myFavoriteProject2.name).rightclick();
-                cy.contains('Add to favorites').click();
-
-                cy.doMPVTabSelect("Data");
-
                 //add two projects to public favorites
                 cy.get('[data-cy=data-table]').contains(myPublicFavoriteProject1.name).rightclick();
                 cy.contains('Add to public favorites').click();

--- a/services/workbench2/cypress/e2e/favorites.cy.js
+++ b/services/workbench2/cypress/e2e/favorites.cy.js
@@ -304,12 +304,12 @@ describe('Favorites-SidePanel tests', function () {
         });
 
         cy.loginAs(adminUser);
+        cy.doSidePanelNavigation('Home Projects');
 
         cy.getAll('@myFavoriteProject1', '@myFavoriteProject2', '@myPublicFavoriteProject1', '@myPublicFavoriteProject2')
         .then(function ([myFavoriteProject1, myFavoriteProject2, myPublicFavoriteProject1, myPublicFavoriteProject2, ]) {
-                cy.doSidePanelNavigation('Home Projects');
 
-                //add two projects and collection to favorites
+                //add two projects to favorites
                 cy.get('[data-cy=side-panel-tree]').contains(myFavoriteProject1.name).rightclick();
                 cy.contains('Add to favorites').click();
                 cy.get('[data-cy=side-panel-tree]').contains(myFavoriteProject2.name).rightclick();
@@ -355,11 +355,21 @@ describe('Favorites-SidePanel tests', function () {
                 cy.get(`[data-cy=tree-item-toggle-public-favorites]`).click();
                 cy.get('span').contains(myPublicFavoriteProject1.name).should('exist');
                 cy.get('span').contains(myPublicFavoriteProject2.name).should('exist');
-                cy.get(`[data-cy=tree-item-toggle-public-favorites]`).click();
+        });
+    });
 
-                // Keep favorites open
-                cy.get(`[data-cy=tree-item-toggle-my-favorites]`).click();
+    it('restores trashed favorite project to favorites', () => {
+        cy.createProject({
+            owningUser: adminUser,
+            projectName: `myFavoriteProject1`,
+            addToFavorites: true,
+        });
 
+        cy.loginAs(adminUser);
+        cy.doSidePanelNavigation('Home Projects');
+
+        cy.get('@myFavoriteProject1')
+            .then(function (myFavoriteProject1) {
                 // Trash favorited project
                 cy.get('[data-cy=data-table]').contains(myFavoriteProject1.name).rightclick();
                 cy.get('[data-cy=context-menu]').contains('Move to trash').click();
@@ -375,8 +385,10 @@ describe('Favorites-SidePanel tests', function () {
                 cy.assertBreadcrumbs(["Home Projects", myFavoriteProject1.name]);
                 // Check project restored to favorites
                 cy.wait(1000);
+                // Open favorites
+                cy.get(`[data-cy=tree-item-toggle-my-favorites]`).click();
                 cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('contain', myFavoriteProject1.name);
-        });
+            });
     });
 
     it('restores trashed favorite collection to favorites', () => {
@@ -395,9 +407,10 @@ describe('Favorites-SidePanel tests', function () {
                 cy.waitForDom()
                 cy.get('[data-cy=data-table]').contains(testFavoriteCollection.name).rightclick();
                 cy.get('[data-cy=context-menu]').contains('Move to trash').click();
-                // Check removed from favorites
+                // Keep the favorites open
                 cy.get('[data-cy=tree-item-toggle-my-favorites]').click({ force: true })
                 cy.wait(1000);
+                // Check removed from favorites
                 cy.get('[data-cy=side-panel-tree]').should('not.contain', testFavoriteCollection.name);
                 // Untrash favorited collection
                 cy.get('[data-cy=side-panel-tree]').contains('Trash').click();

--- a/services/workbench2/cypress/e2e/favorites.cy.js
+++ b/services/workbench2/cypress/e2e/favorites.cy.js
@@ -302,14 +302,11 @@ describe('Favorites-SidePanel tests', function () {
             owningUser: adminUser,
             projectName: `myPublicFavoriteProject2`,
         });
-        cy.createCollection(adminUser.token, {
-            owner_uuid: adminUser.user.uuid,
-            name: `Test favorite collection ${Math.floor(Math.random() * 999999)}`,
-        }).as('testFavoriteCollection');
+
+        cy.loginAs(adminUser);
 
         cy.getAll('@myFavoriteProject1', '@myFavoriteProject2', '@myPublicFavoriteProject1', '@myPublicFavoriteProject2')
         .then(function ([myFavoriteProject1, myFavoriteProject2, myPublicFavoriteProject1, myPublicFavoriteProject2, ]) {
-                cy.loginAs(adminUser);
                 cy.doSidePanelNavigation('Home Projects');
 
                 //add two projects and collection to favorites
@@ -380,10 +377,17 @@ describe('Favorites-SidePanel tests', function () {
                 cy.wait(1000);
                 cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('contain', myFavoriteProject1.name);
         });
+    });
 
+    it('restores trashed favorite collection to favorites', () => {
+        cy.createCollection(adminUser.token, {
+            owner_uuid: adminUser.user.uuid,
+            name: `Test favorite collection ${Math.floor(Math.random() * 999999)}`,
+        }).as('testFavoriteCollection');
+
+        cy.loginAs(adminUser);
         cy.getAll('@testFavoriteCollection')
             .then(function ([testFavoriteCollection]) {
-                cy.loginAs(adminUser);
                 cy.get('[data-cy=side-panel-tree]').contains('Home Projects').click().waitForDom();
                 cy.doMPVTabSelect("Data");
                 cy.get('[data-cy=data-table]').contains(testFavoriteCollection.name).rightclick();

--- a/services/workbench2/cypress/e2e/favorites.cy.js
+++ b/services/workbench2/cypress/e2e/favorites.cy.js
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: AGPL-3.0
 
-const kebabCase = require('lodash/kebabCase');
-
 describe('Favorites tests', function () {
     let activeUser;
     let adminUser;
@@ -318,7 +316,7 @@ describe('Favorites-SidePanel tests', function () {
                 cy.contains('Add to public favorites').click();
 
                 //close "Home Projects", which is open by default
-                cy.get(`[data-cy=tree-item-toggle-${kebabCase(adminUser.user.uuid)}]`).click();
+                cy.get(`[data-cy=tree-item-toggle-${adminUser.user.uuid}]`).click();
 
                 //check if the correct favorites are displayed in the side panel
                 cy.get('span').contains(myFavoriteProject1.name).should('not.exist');

--- a/services/workbench2/cypress/e2e/favorites.cy.js
+++ b/services/workbench2/cypress/e2e/favorites.cy.js
@@ -375,26 +375,31 @@ describe('Favorites-SidePanel tests', function () {
         cy.get('[data-cy=tree-item-toggle-my-favorites]').click();
 
         cy.get('@myFavoriteProject1')
-            .then(function (myFavoriteProject1) {
+            .its("name")
+            .then((projName) => {
                 // Trash favorited project
-                cy.get('[data-cy=data-table]').contains(myFavoriteProject1.name).rightclick();
+                cy.get('[data-cy=data-table]').contains(projName).rightclick();
                 cy.get('[data-cy=context-menu]').contains('Move to trash').click();
                 // Snackbar assertion as a barrier
                 cy.get("[data-cy=snackbar]").should("contain", "Item trashed");
 
                 // Check removed from favorites
-                cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('not.contain', myFavoriteProject1.name);
+                cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('not.contain', projName);
 
                 // Untrash favorited project
                 cy.get('[data-cy=side-panel-tree]').contains('Trash').click();
-                cy.get('[data-cy=data-table]').contains(myFavoriteProject1.name).rightclick();
+                // Project might not be on first page
+                cy.get('[data-cy=search-input] input').type(`${projName}{enter}`);
+                cy.get('[data-cy=data-table]').contains(projName).rightclick();
                 cy.get('[data-cy=context-menu]').contains('Restore').click();
+            });
 
-                // Snackbar assertion as a barrier
-                cy.get("[data-cy=snackbar]").should("contain", "Item untrashed");
-
+        cy.get('@myFavoriteProject1')
+            .then((myFavoriteProject1) => {
                 // Check project restored to favorites
-                cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('contain', myFavoriteProject1.name);
+                cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').within(() => {
+                    cy.get(`[data-id="${myFavoriteProject1.uuid}"]`, { timeout: 6000 }).should("contain", myFavoriteProject1.name);
+                });
             });
     });
 
@@ -412,7 +417,9 @@ describe('Favorites-SidePanel tests', function () {
         cy.createCollection(adminUser.token, {
             owner_uuid: adminUser.user.uuid,
             name: collName,
-        });
+        })
+            .its("uuid")
+            .as("testCollectionUuid");
 
         cy.loginAs(adminUser);
         cy.goToPath(`/projects/${adminUser.user.uuid}`);
@@ -434,12 +441,16 @@ describe('Favorites-SidePanel tests', function () {
 
         // Untrash favorited collection
         cy.get('[data-cy=side-panel-tree]').contains('Trash').click();
+        // Collection might not be on first page
+        cy.get('[data-cy=search-input] input').type(`${collName}{enter}`);
         cy.get('[data-cy=data-table]').contains(collName).rightclick();
         cy.get('[data-cy=context-menu]').contains('Restore').click();
-        // Snackbar assertion as a barrier
-        cy.get("[data-cy=snackbar]").should("contain", "Item untrashed");
-
         // Check collection restored to favorites
-        cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').should('contain', collName);
+        cy.get("@testCollectionUuid")
+            .then((uuid) => {
+                cy.get('[data-cy=tree-item-toggle-my-favorites]').parents('[data-cy=tree-top-level-item]').within(() => {
+                    cy.get(`[data-id="${uuid}"]`, { timeout: 6000 }).should("contain", collName);
+                })
+            });
     });
 });

--- a/services/workbench2/src/components/tree/tree.tsx
+++ b/services/workbench2/src/components/tree/tree.tsx
@@ -14,13 +14,12 @@ import classnames from "classnames";
 import { getNodeChildrenIds, Tree, getNode, initTreeNode, createTree } from 'models/tree';
 import { ArvadosTheme } from 'common/custom-theme';
 import { SidePanelRightArrowIcon } from '../icon/icon';
-import { Resource, ResourceKind } from 'models/resource';
+import { Resource, ResourceKind, isResourceUuid } from 'models/resource';
 import { GroupClass } from 'models/group';
 import { SidePanelTreeCategory } from 'store/side-panel-tree/side-panel-tree-actions';
-import { kebabCase } from 'lodash';
 import { ResourcesState, getResource } from 'store/resources/resources';
 import { TreePicker } from 'store/tree-picker/tree-picker';
-import { isEqual } from 'lodash';
+import { kebabCase, isEqual } from 'lodash';
 
 type CssRules = 'list'
               | 'listItem'
@@ -449,6 +448,10 @@ export const TreeComponent = withStyles(styles)(
                 if (isInFavoritesTree(it) && it.open === true && it.items && it.items.length) {
                     it = { ...it, items: it.items.filter(item => item.depth && item.depth < 3) }
                 }
+                let toggleId = it.id.toString();
+                if (!isResourceUuid(toggleId)) {
+                    toggleId = kebabCase(toggleId);
+                }
                 return <div data-cy="tree-top-level-item" key={`item/${level}/${it.id}`}>
                     <ListItem button className={listItem}
                         data-cy="tree-li"
@@ -465,7 +468,7 @@ export const TreeComponent = withStyles(styles)(
                         <i onClick={(e) => handleToggleItemOpen(it, e)}
                             className={toggableIconContainer}>
                             <ListItemIcon className={getToggableIconClassNames(it.open, it.active)}
-                                data-cy={`tree-item-toggle-${kebabCase(it.id.toString())}`}
+                                data-cy={`tree-item-toggle-${toggleId}`}
                                 >
                                 {getProperArrowAnimation(it.status, it.items!)}
                             </ListItemIcon>


### PR DESCRIPTION
`514-wb-fix-favorites-e2e-tests` @ 2dc7d19af1ff33f4815a339840103e8820e3870a

* For this branch, favorites e2e tests only:
  https://ci.arvados.org/job/developer-run-tests/5176/
* For recent WB testing changes (merged bundle of this branch, `491-clean-up-cypress-collection-e2e-tests-for-maintainability-and-reliability`, and `514-wb-various-e2e-test-fixes`)
  https://ci.arvados.org/job/developer-run-tests/5174/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * The `favorites.cy.js` failures ([example](https://ci.arvados.org/job/run-tests-services-workbench2-integration/1289)) originated from the custom Cypress command `cy.waitForDom()` timing out. The error output is not very helpful, being a Cypress limitation when the command fails in a big monolithic `.then()` block.
  * To fix this, the offending test ("Favorites-SidePanel tests" > "shows the correct favorites and public favorites in the side panel") has been broken into three tests for better isolation:
    1. the original one "it shows the correct favorites and public favorites in the side panel" now only tests what it says in the title, that the correct items are shown / removed in the "My Favorites" and "Public Favorites" side panel sections.
    2. new test split off the original large test, "it restores trashed favorite project to favorites", to test restoration to "My Favorites" side panel of a faved but trashed project.
    3. another split-off test "it restores trashed favorite collection to favorites", similar to the above, for faved but trashed collection.
  * In these tests, we reduced the use of `cy.waitForDom()` which is resource-heavy (observing mutations on `window.document.body` and its entire subtree) and often introduces unpredictability.
  * When checking for the desired outcome in these tests, we used to do a `cy.wait(1000)` (unconditional pause of 1s) followed by a subtree text-content assertion on the container element (The "My Favorites" section in the side panel). The latter assertion may still timeout during the fairly XHR-heavy "restore resource with fave status and update UI" operation. In this fix, we instead get rid of the `cy.wait()` and use a different query-assertion strategy. We simply locate the parent (container) element, and query-and-assert precisely (using `data-id` attribute) on the expected child element that should contain the project/collection about to be restored, with a longer-than-default timeout.
  * We also applied some techniques for faster and reliable testing, such as setting up state by Arvados API calls rather than by Web UI (point and click).
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * See above
  * Repeat manual testing in Cypress app.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_ (no change)
* Documentation has been updated.
  * _N/A_
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_ (for test infrastructure only)
* Considered backwards and forwards compatibility issues between client and server.
  * Not affected
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _Yes_, mostly

Partially addresses #514.