### PR TITLE
491: Clean up Cypress collection e2e tests for maintainability and reliability

### DIFF
--- a/services/workbench2/cypress/e2e/collection.cy.js
+++ b/services/workbench2/cypress/e2e/collection.cy.js
@@ -5,6 +5,21 @@
 const path = require("path");
 require('cypress-plugin-tab')
 
+// It can be tricky to mimick the user's navigation and eyeballing for a newly
+// created (but not shown) collection by its known (and unique) name, which can
+// be noisy, time consuming, and a bit flaky. We locate the collection by API
+// directly and jump to it.
+function goToCollectionByName(collectionName, token) {
+    return cy.doRequest("GET", "/arvados/v1/collections", null, {
+        filters: JSON.stringify([["name", "=", collectionName]]),
+        limit: "1",
+        select: JSON.stringify(["uuid"]),
+        count: "none"
+    }, token, true)
+        .its("body.items.0.uuid")
+        .then(uuid => cy.goToPath(`/collections/${uuid}`));
+}
+
 describe("Collection panel tests", function () {
     let activeUser;
     let adminUser;
@@ -924,10 +939,7 @@ describe("Collection panel tests", function () {
 
                 cy.get("[data-cy=form-submit-btn]").click();
 
-                cy.waitForDom().get(".layout-pane-primary", { timeout: 12000 }).contains("Projects").click();
-
-                cy.doMPVTabSelect("Data");
-                cy.waitForDom().get("main").contains(`Files extracted from: ${this.collection.name}`).click();
+                goToCollectionByName(`Files extracted from: ${this.collection.name}`, activeUser.token);
                 cy.doMPVTabSelect("Files");
                 cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
             });
@@ -1004,14 +1016,10 @@ describe("Collection panel tests", function () {
             cy.get("[data-cy=form-submit-btn]").click();
 
             // Verify created collections
-            cy.waitForDom().get(".layout-pane-primary", { timeout: 12000 }).contains("Projects").click();
-            cy.doMPVTabSelect("Data");
-            cy.get("main").contains(`File copied from collection ${sourceCollection.name}/foo`).click();
+            goToCollectionByName(`File copied from collection ${sourceCollection.name}/foo`, activeUser.token);
             cy.doMPVTabSelect("Files");
             cy.get("[data-cy=collection-files-panel]").and("contain", "foo");
-            cy.get(".layout-pane-primary").contains("Projects").click();
-            cy.doMPVTabSelect("Data");
-            cy.get("main").contains(`File copied from collection ${sourceCollection.name}/bar`).click();
+            goToCollectionByName(`File copied from collection ${sourceCollection.name}/bar`, activeUser.token);
             cy.doMPVTabSelect("Files");
             cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
 
@@ -1054,10 +1062,7 @@ describe("Collection panel tests", function () {
 
                 cy.get("[data-cy=form-submit-btn]").click();
 
-                cy.waitForDom().get(".layout-pane-primary", { timeout: 12000 }).contains("Projects").click();
-
-                cy.doMPVTabSelect("Data");
-                cy.get("main").contains(`Files moved from: ${this.collection.name}`).click();
+                goToCollectionByName(`Files moved from: ${this.collection.name}`, activeUser.token);
                 cy.doMPVTabSelect("Files");
                 cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
             });
@@ -1124,7 +1129,7 @@ describe("Collection panel tests", function () {
                 cy.get("input[type=checkbox]").last().click();
             });
 
-            // Copy to separate collections
+            // Move to separate collections
             cy.get("[data-cy=collection-files-panel-options-btn]").click();
             cy.get("[data-cy=context-menu]").contains("Move selected into separate collections").click();
             cy.get("[data-cy=form-dialog]").contains("Projects").click();
@@ -1132,16 +1137,13 @@ describe("Collection panel tests", function () {
             cy.get("[data-cy=form-dialog]").should("not.exist", { timeout: 10000 });
 
             // Verify created collections
-            cy.waitForDom().get(".layout-pane-primary", { timeout: 12000 }).contains("Projects").click();
-            cy.doMPVTabSelect("Data");
-            cy.get("main").contains(`File moved from collection ${sourceCollection.name}/foo`).click();
+            goToCollectionByName(`File moved from collection ${sourceCollection.name}/foo`, activeUser.token);
             cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").and("contain", "foo");
-            cy.get(".layout-pane-primary").contains("Projects").click();
-            cy.doMPVTabSelect("Data");
-            cy.get("main").contains(`File moved from collection ${sourceCollection.name}/bar`).click();
+            cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='foo']").should("be.visible");
+
+            goToCollectionByName(`File moved from collection ${sourceCollection.name}/bar`, activeUser.token);
             cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
+            cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='bar']").should("be.visible");
         });
     });
 

--- a/services/workbench2/cypress/e2e/collection.cy.js
+++ b/services/workbench2/cypress/e2e/collection.cy.js
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0
 
 const path = require("path");
-require('cypress-plugin-tab')
+require('cypress-plugin-tab');
 
 // It can be tricky to mimick the user's navigation and eyeballing for a newly
 // created (but not shown) collection by its known (and unique) name, which can
@@ -44,6 +44,8 @@ describe("Collection panel tests", function () {
     });
 
     it("allows to download mountain duck config for a collection", () => {
+        // Creates the collection using the admin token so we can set up
+        // a bogus manifest text without block signatures.
         cy.createCollection(adminUser.token, {
             name: `Test collection ${Math.floor(Math.random() * 999999)}`,
             owner_uuid: activeUser.user.uuid,
@@ -105,9 +107,7 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=form-dialog]")
             .should("contain", "New collection")
             .within(() => {
-                cy.get("[data-cy=name-field]").within(() => {
-                    cy.get("input").type(name);
-                });
+                cy.get("[data-cy=name-field] input").type(name);
                 cy.get("[data-cy=form-submit-btn]").click();
             });
         // Error message should display, allowing editing the name
@@ -115,10 +115,8 @@ describe("Collection panel tests", function () {
             .should("exist")
             .and("contain", "Collection with the same name already exists")
             .within(() => {
-                cy.get("[data-cy=name-field]").within(() => {
-                    cy.get("input").type(" renamed");
-                });
-                cy.get("[data-cy=form-submit-btn]").click({timeout: 10000});
+                cy.get("[data-cy=name-field] input").type(" renamed");
+                cy.get("[data-cy=form-submit-btn]").click();
             });
         cy.get("[data-cy=form-dialog]").should("not.exist");
         // Attempt to rename the collection with the duplicate name
@@ -126,9 +124,7 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=form-dialog]")
             .should("contain", "Edit Collection")
             .within(() => {
-                cy.get("[data-cy=name-field]").within(() => {
-                    cy.get("input").type("{selectall}{backspace}").type(name);
-                });
+                cy.get("[data-cy=name-field] input").type("{selectall}{backspace}").type(name);
                 cy.get("[data-cy=form-submit-btn]").click();
             });
         cy.get("[data-cy=form-dialog]").should("exist").and("contain", "Collection with the same name already exists");
@@ -226,14 +222,11 @@ describe("Collection panel tests", function () {
                 // Case-insensitive on-blur auto-selection test
                 // Key: Size (IDTAGSIZES) - Value: Small (IDVALSIZES2)
                 cy.get("[data-cy=resource-properties-form]").within(() => {
-                    cy.get("[data-cy=property-field-key]").within(() => {
-                        cy.get("input").type("sIzE");
-                    });
+                    cy.get("[data-cy=property-field-key] input").type("sIzE");
                     cy.get("[data-cy=property-field-value]").click().within(() => {
                         cy.get("input").type("sMaLL{enter}");
                     });
                     cy.get("[data-cy=property-add-btn]").click();
-                    cy.waitForDom();
                 });
                 // Confirm proper vocabulary labels are displayed on the UI.
                 cy.get("[data-cy=form-dialog]").should("contain", "Size: S");
@@ -269,104 +262,105 @@ describe("Collection panel tests", function () {
                 name: "Shared project",
                 group_class: "project",
             })
-                .as("sharedGroup")
-                .then(function () {
-                    // Creates the collection using the admin token so we can set up
-                    // a bogus manifest text without block signatures.
-                    cy.doRequest("GET", "/arvados/v1/config", null, null)
-                        .its("body")
-                        .should(clusterConfig => {
-                            expect(clusterConfig.Collections, "clusterConfig").to.have.property("TrustAllContent", true);
-                            expect(clusterConfig.Services, "clusterConfig").to.have.property("WebDAV").have.property("ExternalURL");
-                            expect(clusterConfig.Services, "clusterConfig").to.have.property("WebDAVDownload").have.property("ExternalURL");
-                            const inlineUrl =
-                                clusterConfig.Services.WebDAV.ExternalURL !== ""
-                                    ? clusterConfig.Services.WebDAV.ExternalURL
-                                    : clusterConfig.Services.WebDAVDownload.ExternalURL;
-                            expect(inlineUrl).to.not.contain("*");
-                        })
-                        .createCollection(adminUser.token, {
-                            name: "Test collection",
-                            owner_uuid: this.sharedGroup.uuid,
-                            properties: { someKey: "someValue" },
-                            manifest_text: `. 37b51d194a7513e45b56f6524f2d51f2+3 0:3:${fileName}\n./${subDirName} 37b51d194a7513e45b56f6524f2d51f2+3 0:3:${fileName}\n`,
-                        })
-                        .as("testCollection")
-                        .then(function () {
-                            // Share the group with active user.
-                            cy.createLink(adminUser.token, {
-                                name: isWritable ? "can_write" : "can_read",
-                                link_class: "permission",
-                                head_uuid: this.sharedGroup.uuid,
-                                tail_uuid: activeUser.user.uuid,
-                            });
-                            cy.goToPath(`/collections/${this.testCollection.uuid}`);
+                .as("sharedGroup");
 
-                            // Verify collection name
-                            cy.get("[data-cy=collection-details-card]")
-                                .should("contain", this.testCollection.name);
+            cy.doRequest("GET", "/arvados/v1/config", null, null)
+                .its("body")
+                .should(clusterConfig => {
+                    expect(clusterConfig.Collections, "clusterConfig").to.have.property("TrustAllContent", true);
+                    expect(clusterConfig.Services, "clusterConfig").to.have.property("WebDAV").have.property("ExternalURL");
+                    expect(clusterConfig.Services, "clusterConfig").to.have.property("WebDAVDownload").have.property("ExternalURL");
+                    const inlineUrl =
+                        clusterConfig.Services.WebDAV.ExternalURL !== ""
+                            ? clusterConfig.Services.WebDAV.ExternalURL
+                            : clusterConfig.Services.WebDAVDownload.ExternalURL;
+                    expect(inlineUrl).to.not.contain("*");
+                })
 
-                            // Open overview tab
-                            cy.doMPVTabSelect("Overview");
+            cy.get("@sharedGroup").then(sharedGroup => {
+                cy.createCollection(adminUser.token, {
+                    name: "Test collection",
+                    owner_uuid: sharedGroup.uuid,
+                    properties: { someKey: "someValue" },
+                    manifest_text: `. 37b51d194a7513e45b56f6524f2d51f2+3 0:3:${fileName}\n./${subDirName} 37b51d194a7513e45b56f6524f2d51f2+3 0:3:${fileName}\n`,
+                })
+                    .as("testCollection");
 
-                            // Verify collection uuid
-                            cy.get("[data-cy=details-element]")
-                                .should("contain", this.testCollection.uuid)
-                                .and("not.contain", "This is an old version");
-
-                            // Check for the read-only icon
-                            cy.get("[data-cy=read-only-icon]").should(`${isWritable ? "not." : ""}exist`);
-                            // Check that both read and write operations are available on
-                            // the 'More options' menu.
-                            cy.get("[data-cy=collection-details-card]").within(() => {
-                                cy.get("[data-targetid='Add to favorites']");
-                                if (isWritable) {
-                                    cy.get("[data-targetid='Edit collection']");
-                                } else {
-                                    cy.get("[data-targetid='Edit collection']").should("not.exist");
-                                }
-                            });
-                            cy.get("body").click(); // Collapse the menu avoiding details panel expansion
-                            cy.get("[data-cy=resource-properties]")
-                                .should("contain", "someKey: someValue")
-                                .and("not.contain", "anotherKey: anotherValue");
-                            // Check that the file listing show both read & write operations
-                            cy.waitForDom();
-                            cy.doMPVTabSelect("Files");
-                            cy.get("[data-cy=collection-files-right-panel]", { timeout: 5000 }).should("contain", fileName);
-                            if (isWritable) {
-                                cy.get("[data-cy=upload-button]").should(`${isWritable ? "" : "not."}contain`, "Upload data");
-                            }
-                            // Test context menus
-                            cy.get("[data-cy=collection-files-panel]").contains(fileName).rightclick();
-                            cy.get("[data-cy=context-menu]")
-                                .should("contain", "Download")
-                                .and("contain", "Open in new tab")
-                                .and("contain", "Copy link to latest version")
-                                .and("contain", "Copy link to immutable version")
-                                .and(`${isWritable ? "" : "not."}contain`, "Rename")
-                                .and(`${isWritable ? "" : "not."}contain`, "Remove");
-                            cy.get("body").click(); // Collapse the menu
-                            cy.get("[data-cy=collection-files-panel]").contains(subDirName).rightclick();
-                            cy.get("[data-cy=context-menu]")
-                                .should("not.contain", "Download")
-                                .and("contain", "Open in new tab")
-                                .and("contain", "Copy link to latest version")
-                                .and("contain", "Copy link to immutable version")
-                                .and(`${isWritable ? "" : "not."}contain`, "Rename")
-                                .and(`${isWritable ? "" : "not."}contain`, "Remove");
-                            cy.get("body").click(); // Collapse the menu
-                            // File/dir item 'more options' button
-                            cy.get("[data-cy=file-item-options-btn").first().click();
-                            cy.get("[data-cy=context-menu]").should(`${isWritable ? "" : "not."}contain`, "Remove");
-                            cy.get("body").click(); // Collapse the menu
-                            // Hamburger 'more options' menu button
-                            cy.doCollectionPanelOptionsAction("Select all");
-                            cy.get("[data-cy=collection-files-panel-options-btn]").click();
-                            cy.get("[data-cy=context-menu]").should(`${isWritable ? "" : "not."}contain`, "Remove selected");
-                            cy.get("body").click(); // Collapse the menu
-                        });
+                // Share the group with active user.
+                cy.createLink(adminUser.token, {
+                    name: isWritable ? "can_write" : "can_read",
+                    link_class: "permission",
+                    head_uuid: sharedGroup.uuid,
+                    tail_uuid: activeUser.user.uuid,
                 });
+            });
+
+            cy.get("@testCollection").then(testCollection => {
+                cy.goToPath(`/collections/${testCollection.uuid}`);
+                // Verify collection name
+                cy.get("[data-cy=collection-details-card]")
+                    .should("contain", testCollection.name);
+
+                // Open overview tab
+                cy.doMPVTabSelect("Overview");
+
+                // Verify collection uuid
+                cy.get("[data-cy=details-element]")
+                    .should("contain", testCollection.uuid)
+                    .and("not.contain", "This is an old version");
+            });
+
+            // Check for the read-only icon
+            cy.get("[data-cy=read-only-icon]").should(`${isWritable ? "not." : ""}exist`);
+            // Check that both read and write operations are available on
+            // the 'More options' menu.
+            cy.get("[data-cy=collection-details-card]").within(() => {
+                cy.get("[data-targetid='Add to favorites']");
+                if (isWritable) {
+                    cy.get("[data-targetid='Edit collection']");
+                } else {
+                    cy.get("[data-targetid='Edit collection']").should("not.exist");
+                }
+            });
+            cy.get("body").click(); // Collapse the menu avoiding details panel expansion
+            cy.get("[data-cy=resource-properties]")
+                .should("contain", "someKey: someValue")
+                .and("not.contain", "anotherKey: anotherValue");
+            // Check that the file listing show both read & write operations
+            cy.waitForDom();
+            cy.doMPVTabSelect("Files");
+            cy.get("[data-cy=collection-files-right-panel]", { timeout: 5000 }).should("contain", fileName);
+            if (isWritable) {
+                cy.get("[data-cy=upload-button]").should(`${isWritable ? "" : "not."}contain`, "Upload data");
+            }
+            // Test context menus
+            cy.get("[data-cy=collection-files-panel]").contains(fileName).rightclick();
+            cy.get("[data-cy=context-menu]")
+                .should("contain", "Download")
+                .and("contain", "Open in new tab")
+                .and("contain", "Copy link to latest version")
+                .and("contain", "Copy link to immutable version")
+                .and(`${isWritable ? "" : "not."}contain`, "Rename")
+                .and(`${isWritable ? "" : "not."}contain`, "Remove");
+            cy.get("body").click(); // Collapse the menu
+            cy.get("[data-cy=collection-files-panel]").contains(subDirName).rightclick();
+            cy.get("[data-cy=context-menu]")
+                .should("not.contain", "Download")
+                .and("contain", "Open in new tab")
+                .and("contain", "Copy link to latest version")
+                .and("contain", "Copy link to immutable version")
+                .and(`${isWritable ? "" : "not."}contain`, "Rename")
+                .and(`${isWritable ? "" : "not."}contain`, "Remove");
+            cy.get("body").click(); // Collapse the menu
+            // File/dir item 'more options' button
+            cy.get("[data-cy=file-item-options-btn").first().click();
+            cy.get("[data-cy=context-menu]").should(`${isWritable ? "" : "not."}contain`, "Remove");
+            cy.get("body").click(); // Collapse the menu
+            // Hamburger 'more options' menu button
+            cy.doCollectionPanelOptionsAction("Select all");
+            cy.get("[data-cy=collection-files-panel-options-btn]").click();
+            cy.get("[data-cy=context-menu]").should(`${isWritable ? "" : "not."}contain`, "Remove selected");
+            cy.get("body").click(); // Collapse the menu
         });
     });
 
@@ -376,173 +370,152 @@ describe("Collection panel tests", function () {
                 func(lst[i], lst[i + 1]);
             }
         }
-        // Creates the collection using the admin token so we can set up
-        // a bogus manifest text without block signatures.
+
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
             name: `Test collection ${Math.floor(Math.random() * 999999)}`,
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
-        })
-            .as("testCollection")
-            .then(function () {
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.testCollection.uuid}`);
+        }).then(collection => cy.goToPath(`/collections/${collection.uuid}`));
 
-                const names = [
-                    "bar", // initial name already set
-                    "&",
-                    "foo",
-                    "&amp;",
-                    "I ❤️ ⛵️",
-                    "...",
-                    "#..",
-                    "some name with whitespaces",
-                    "some name with #2",
-                    "is this name legal? I hope it is",
-                    "some_file.pdf#",
-                    "some_file.pdf?",
-                    "?some_file.pdf",
-                    "some%file.pdf",
-                    "some%2Ffile.pdf",
-                    "some%22file.pdf",
-                    "some%20file.pdf",
-                    "G%C3%BCnter's%20file.pdf",
-                    "table%&?*2",
-                    "bar", // make sure we can go back to the original name as a last step
-                ];
-                cy.intercept({ method: "PUT", url: "**/arvados/v1/collections/*" }).as("renameRequest");
-                cy.doMPVTabSelect("Files");
-                eachPair(names, (from, to) => {
-                    cy.waitForDom().get("[data-cy=collection-files-panel]").contains(`${from}`).rightclick();
-                    cy.get("[data-cy=context-menu]").contains("Rename").click();
-                    cy.get("[data-cy=form-dialog]")
-                        .should("contain", "Rename")
-                        .within(() => {
-                            cy.get("input").type("{selectall}{backspace}").type(to, { parseSpecialCharSequences: false });
-                        });
-                    cy.get("[data-cy=form-submit-btn]").click();
-                    cy.wait("@renameRequest");
-                    cy.get("[data-cy=collection-files-panel]").should("not.contain", `${from}`).and("contain", `${to}`);
+        const names = [
+            "bar", // initial name already set
+            "&",
+            "foo",
+            "&amp;",
+            "I ❤️ ⛵️",
+            "...",
+            "#..",
+            "some name with whitespaces",
+            "some name with #2",
+            "is this name legal? I hope it is",
+            "some_file.pdf#",
+            "some_file.pdf?",
+            "?some_file.pdf",
+            "some%file.pdf",
+            "some%2Ffile.pdf",
+            "some%22file.pdf",
+            "some%20file.pdf",
+            "G%C3%BCnter's%20file.pdf",
+            "table%&?*2",
+            "bar", // make sure we can go back to the original name as a last step
+        ];
+        cy.intercept({ method: "PUT", url: "**/arvados/v1/collections/*" }).as("renameRequest");
+
+        cy.doMPVTabSelect("Files");
+        eachPair(names, (from, to) => {
+            cy.get("[data-cy=collection-files-panel]").contains(`${from}`).rightclick();
+            cy.get("[data-cy=context-menu]").contains("Rename").click();
+            cy.get("[data-cy=form-dialog]")
+                .should("contain", "Rename")
+                .within(() => {
+                    cy.get("input").type("{selectall}{backspace}").type(to, { parseSpecialCharSequences: false });
                 });
-            });
+            cy.get("[data-cy=form-submit-btn]").click();
+            cy.wait("@renameRequest");
+            cy.get("[data-cy=collection-files-panel]").should("not.contain", `${from}`).and("contain", `${to}`);
+        });
     });
 
     it("renames a file to a different directory", function () {
-        // Creates the collection using the admin token so we can set up
-        // a bogus manifest text without block signatures.
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
             name: `Test collection ${Math.floor(Math.random() * 999999)}`,
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
-        })
-            .as("testCollection")
-            .then(function () {
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.testCollection.uuid}`);
+        }).then(collection => cy.goToPath(`/collections/${collection.uuid}`));
 
-                cy.doMPVTabSelect("Files");
-                ["subdir", "G%C3%BCnter's%20file", "table%&?*2"].forEach(subdir => {
-                    cy.waitForDom().get("[data-cy=collection-files-panel]").contains("bar").rightclick();
-                    cy.get("[data-cy=context-menu]").contains("Rename").click();
-                    cy.get("[data-cy=form-dialog]")
-                        .should("contain", "Rename")
-                        .within(() => {
-                            cy.get("input").type(`{selectall}{backspace}${subdir}/foo`);
-                        });
-                    cy.get("[data-cy=form-submit-btn]").click();
-                    cy.waitForDom();
-                    cy.get("[data-cy=form-dialog]").should("not.exist");
-                    cy.get("[data-cy=collection-files-panel]").should("not.contain", "bar").and("contain", subdir);
-                    cy.get("[data-cy=collection-files-panel]").contains(subdir).click();
-
-                    // Rename 'subdir/foo' to 'bar'
-                    cy.waitForDom();
-                    cy.get("[data-cy=collection-files-panel]").contains("foo").rightclick();
-                    cy.get("[data-cy=context-menu]").contains("Rename").click();
-                    cy.get("[data-cy=form-dialog]")
-                        .should("contain", "Rename")
-                        .within(() => {
-                            cy.get("input").should("have.value", `${subdir}/foo`).type(`{selectall}{backspace}bar`);
-                        });
-                    cy.get("[data-cy=form-submit-btn]").click({ force: true });
-
-                    // need to wait for dialog to dismiss
-                    cy.get("[data-cy=form-dialog]").should("not.exist");
-
-                    cy.waitForDom().get("[data-cy=collection-files-panel]").contains("Home").click();
-
-                    cy.waitForDom();
-                    cy.get("[data-cy=collection-files-panel]").contains(subdir).click();
-                    cy.get("[data-cy=collection-files-panel]")
-                        .should("contain", subdir) // empty dir kept
-                        .and("contain", "bar");
-
-                    // this is when the dom is actually finished loading
-                    cy.get("[data-cy=file-item-options-btn]", { timeout: 20000 }).first().should('exist')
-
-                    cy.get("[data-cy=collection-files-panel-content]").contains(subdir).rightclick();
-                    cy.get("[data-cy=context-menu]").contains("Remove").click();
-                    cy.get("[data-cy=confirmation-dialog-ok-btn]").click();
-                    cy.get("[data-cy=form-dialog]").should("not.exist");
+        cy.doMPVTabSelect("Files");
+        ["subdir", "G%C3%BCnter's%20file", "table%&?*2"].forEach(subdir => {
+            cy.get("[data-cy=collection-files-panel]").contains("bar").rightclick();
+            cy.get("[data-cy=context-menu]").contains("Rename").click();
+            cy.get("[data-cy=form-dialog]")
+                .should("contain", "Rename")
+                .within(() => {
+                    cy.get("input").type(`{selectall}{backspace}${subdir}/foo`);
                 });
-            });
+            cy.get("[data-cy=form-submit-btn]").click();
+            cy.get("[data-cy=form-dialog]").should("not.exist");
+            cy.get("[data-cy=collection-files-panel]").should("not.contain", "bar").and("contain", subdir);
+            cy.get("[data-cy=collection-files-panel]").contains(subdir).click();
+
+            // Rename 'subdir/foo' to 'bar'
+            cy.get("[data-cy=collection-files-panel]").contains("foo").rightclick();
+            cy.get("[data-cy=context-menu]").contains("Rename").click();
+            cy.get("[data-cy=form-dialog]")
+                .should("contain", "Rename")
+                .within(() => {
+                    cy.get("input").should("have.value", `${subdir}/foo`).type(`{selectall}{backspace}bar`);
+                });
+            cy.get("[data-cy=form-submit-btn]").click({ force: true });
+
+            // need to wait for dialog to dismiss
+            cy.get("[data-cy=form-dialog]").should("not.exist");
+
+            cy.get("[data-cy=collection-files-panel]").contains("Home").click();
+
+            cy.get("[data-cy=collection-files-panel]").contains(subdir).click();
+            cy.get("[data-cy=collection-files-panel]")
+                .should("contain", subdir) // empty dir kept
+                .and("contain", "bar");
+
+            // this is when the dom is actually finished loading
+            cy.get("[data-cy=file-item-options-btn]", { timeout: 20000 }).first().should('exist')
+
+            cy.get("[data-cy=collection-files-panel-content]").contains(subdir).rightclick();
+            cy.get("[data-cy=context-menu]").contains("Remove").click();
+            cy.get("[data-cy=confirmation-dialog-ok-btn]").click();
+            cy.get("[data-cy=form-dialog]").should("not.exist");
+        });
     });
 
     it("shows collection owner", () => {
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
             name: `Test collection ${Math.floor(Math.random() * 999999)}`,
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
-        })
-            .as("testCollection")
-            .then(testCollection => {
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${testCollection.uuid}`);
-                cy.wait(5000);
-                cy.doMPVTabSelect("Overview");
-                cy.get("[data-cy=details-element]").contains(`Collection User`);
-            });
+        }).then(collection => cy.goToPath(`/collections/${collection.uuid}`));
+
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=details-element]").contains(activeUser.user.full_name);
     });
 
     it("tries to rename a file with illegal names", function () {
-        // Creates the collection using the admin token so we can set up
-        // a bogus manifest text without block signatures.
+        const illegalNamesFromUI = [
+            [".", "Name cannot be '.' or '..'"],
+            ["..", "Name cannot be '.' or '..'"],
+            ["", "This field is required"],
+            [" ", "Leading/trailing whitespaces not allowed"],
+            [" foo", "Leading/trailing whitespaces not allowed"],
+            ["foo ", "Leading/trailing whitespaces not allowed"],
+            ["//foo", "Empty dir name not allowed"],
+        ];
+
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
             name: `Test collection ${Math.floor(Math.random() * 999999)}`,
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
         })
-            .as("testCollection")
-            .then(function () {
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.testCollection.uuid}`);
+            .then(testCollection => cy.goToPath(`/collections/${testCollection.uuid}`));
 
-                const illegalNamesFromUI = [
-                    [".", "Name cannot be '.' or '..'"],
-                    ["..", "Name cannot be '.' or '..'"],
-                    ["", "This field is required"],
-                    [" ", "Leading/trailing whitespaces not allowed"],
-                    [" foo", "Leading/trailing whitespaces not allowed"],
-                    ["foo ", "Leading/trailing whitespaces not allowed"],
-                    ["//foo", "Empty dir name not allowed"],
-                ];
-                cy.doMPVTabSelect("Files");
-                illegalNamesFromUI.forEach(([name, errMsg]) => {
-                    cy.get("[data-cy=collection-files-panel]").contains("bar").rightclick();
-                    cy.get("[data-cy=context-menu]").contains("Rename").click();
-                    cy.get("[data-cy=form-dialog]")
-                        .should("contain", "Rename")
-                        .within(() => {
-                            cy.get("input").type(`{selectall}{backspace}${name}`);
-                        });
-                    cy.get("[data-cy=form-dialog]")
-                        .should("contain", "Rename")
-                        .within(() => {
-                            cy.contains(`${errMsg}`);
-                        });
-                    cy.get("[data-cy=form-cancel-btn]").click();
+        cy.doMPVTabSelect("Files");
+        illegalNamesFromUI.forEach(([name, errMsg]) => {
+            cy.get("[data-cy=collection-files-panel]").contains("bar").rightclick();
+            cy.get("[data-cy=context-menu]").contains("Rename").click();
+            cy.get("[data-cy=form-dialog]")
+                .should("contain", "Rename")
+                .within(() => {
+                    cy.get("input").type(`{selectall}{backspace}${name}`);
                 });
-            });
+            cy.get("[data-cy=form-dialog]")
+                .should("contain", "Rename")
+                .within(() => {
+                    cy.contains(errMsg);
+                });
+            cy.get("[data-cy=form-cancel-btn]").click();
+        });
     });
 
     it("can correctly display old versions", function () {
@@ -559,8 +532,6 @@ describe("Collection panel tests", function () {
             .then(function () {
                 expect(this.collections).to.be.empty;
             });
-        // Creates the collection using the admin token so we can set up
-        // a bogus manifest text without block signatures.
         cy.createCollection(adminUser.token, {
             name: colName,
             owner_uuid: activeUser.user.uuid,
@@ -681,30 +652,33 @@ describe("Collection panel tests", function () {
             owner_uuid: activeUser.user.uuid,
         }).as("testProject");
 
-        cy.getAll("@testCollection", "@testProject").then(function ([testCollection, testProject]) {
-            cy.loginAs(activeUser);
-            cy.goToPath(`/collections/${testCollection.uuid}`);
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").should("contain", fileName);
-            cy.get("[data-cy=collection-details-card]").should("not.contain", projName).and("not.contain", testProject.uuid);
-            cy.get('[data-title="Move to"]').click();
-            cy.get("[data-cy=form-dialog]")
-                .should("contain", "Move to")
-                .within(() => {
-                    // must use .then to avoid selecting instead of expanding https://github.com/cypress-io/cypress/issues/5529
-                    cy.get("[data-cy=projects-tree-home-tree-picker]")
-                        .find("i")
-                        .then(el => el.click());
-                    cy.get("[data-cy=projects-tree-home-tree-picker]").contains(projName).click();
-                });
-            cy.get("[data-cy=form-submit-btn]").click();
-            cy.get("[data-cy=snackbar]").contains("Collection has been moved");
-            cy.get("button").contains(projName);
-            // Double check that the collection is in the project
-            cy.goToPath(`/projects/${testProject.uuid}`);
-            cy.doMPVTabSelect("Data");
-            cy.waitForDom().get("[data-cy=project-panel]").should("contain", collName);
+        cy.loginAs(activeUser);
+
+        cy.get("@testCollection").then(testCollection => cy.goToPath(`/collections/${testCollection.uuid}`));
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", fileName);
+        cy.get("@testProject").then(testProject => {
+            cy.get("[data-cy=collection-details-card]")
+                .should("not.contain", projName)
+                .and("not.contain", testProject.uuid);
         });
+        cy.get('[data-title="Move to"]').click();
+        cy.get("[data-cy=form-dialog]")
+            .should("contain", "Move to")
+            .within(() => {
+                // must use .then to avoid selecting instead of expanding https://github.com/cypress-io/cypress/issues/5529
+                cy.get("[data-cy=projects-tree-home-tree-picker]")
+                    .find("i")
+                    .then(el => el.click());
+                cy.get("[data-cy=projects-tree-home-tree-picker]").contains(projName).click();
+            });
+        cy.get("[data-cy=form-submit-btn]").click();
+        cy.get("[data-cy=snackbar]").contains("Collection has been moved");
+        cy.get("button").contains(projName);
+        // Double check that the collection is in the project
+        cy.get("@testProject").then(testProject => cy.goToPath(`/projects/${testProject.uuid}`));
+        cy.doMPVTabSelect("Data");
+        cy.get("[data-cy=project-panel]").should("contain", collName);
     });
 
     it("automatically updates the collection UI contents without using the Refresh button", function () {
@@ -751,167 +725,153 @@ describe("Collection panel tests", function () {
         const collName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
         const copyName = `Copy of: ${collName}`;
 
+        cy.loginAs(activeUser);
+
         cy.createCollection(adminUser.token, {
             name: collName,
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:some-file\n",
         })
-            .as("collection")
-            .then(function () {
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.collection.uuid}`);
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").should("contain", "some-file");
-                cy.get('[data-title="Make a copy"]').click();
-                cy.get("[data-cy=form-dialog]")
-                    .should("contain", "Make a copy")
-                    .within(() => {
-                        cy.get("[data-cy=projects-tree-home-tree-picker]").contains("Projects").click();
-                        cy.get("[data-cy=form-submit-btn]").click();
-                    });
-                cy.get("[data-cy=snackbar]").contains("Collection has been copied.");
-                cy.get("[data-cy=tree-li]").contains("Home Projects").click();
-                cy.doMPVTabSelect("Data");
-                cy.get("[data-cy=project-panel]").contains(copyName).click();
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").should("contain", "some-file");
+            .then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
+
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", "some-file");
+        cy.get('[data-title="Make a copy"]').click();
+        cy.get("[data-cy=form-dialog]")
+            .should("contain", "Make a copy")
+            .within(() => {
+                cy.get("[data-cy=projects-tree-home-tree-picker]").contains("Projects").click();
+                cy.get("[data-cy=form-submit-btn]").click();
             });
+        cy.get("[data-cy=snackbar]").contains("Collection has been copied.");
+
+        goToCollectionByName(copyName, activeUser.token);
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", "some-file");
     });
 
     it("uses the collection version browser to view a previous version", function () {
         const colName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
 
-        // Creates the collection using the admin token so we can set up
-        // a bogus manifest text without block signatures.
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
             name: colName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        })
-            .as("collection")
-            .then(function () {
-                // Visit collection, check basic information
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.collection.uuid}`);
-                cy.doMPVTabSelect("Overview");
+        }).then(collection => cy.goToPath(`/collections/${collection.uuid}`));
 
-                cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
-                cy.get("[data-cy=read-only-icon]").should("not.exist");
-                cy.get("[data-cy=collection-version-number]").should("contain", "1");
-                cy.get("[data-cy=collection-details-card]").should("contain", colName);
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
+        cy.get("[data-cy=read-only-icon]").should("not.exist");
+        cy.get("[data-cy=collection-version-number]").should("contain", "1");
+        cy.get("[data-cy=collection-details-card]").should("contain", colName);
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
 
-                // Modify collection, expect version number change
-                cy.get("[data-cy=collection-files-panel]").contains("foo").rightclick();
-                cy.get("[data-cy=context-menu]").contains("Remove").click();
-                cy.get("[data-cy=confirmation-dialog]").should("contain", "Removing file");
-                cy.get("[data-cy=confirmation-dialog-ok-btn]").click();
-                cy.get("[data-cy=collection-files-panel]").should("not.contain", "foo").and("contain", "bar");
-                cy.doMPVTabSelect("Overview");
-                cy.get("[data-cy=collection-version-number]").should("contain", "2");
+        // Modify collection, expect version number change
+        cy.get("[data-cy=collection-files-panel]").contains("foo").rightclick();
+        cy.get("[data-cy=context-menu]").contains("Remove").click();
+        cy.get("[data-cy=confirmation-dialog]").should("contain", "Removing file");
+        cy.get("[data-cy=confirmation-dialog-ok-btn]").click();
+        cy.get("[data-cy=collection-files-panel]").should("not.contain", "foo").and("contain", "bar");
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=collection-version-number]").should("contain", "2");
 
-                // Click on version number, check version browser. Click on past version.
-                cy.get("[data-cy=collection-version-browser]").should("not.exist");
-                cy.get("[data-cy=collection-version-number]").contains("2").click();
-                cy.get("[data-cy=collection-version-browser]")
-                    .should("contain", "Nr")
-                    .and("contain", "Size")
-                    .and("contain", "Date")
-                    .within(() => {
-                        // Version 1: 6 bytes in size
-                        cy.get("[data-cy=collection-version-browser-select-1]")
-                            .should("contain", "1")
-                            .and("contain", "6 B")
-                            .and("contain", adminUser.user.full_name);
-                        // Version 2: 3 bytes in size (one file removed)
-                        cy.get("[data-cy=collection-version-browser-select-2]")
-                            .should("contain", "2")
-                            .and("contain", "3 B")
-                            .and("contain", activeUser.user.full_name);
-                        cy.get("[data-cy=collection-version-browser-select-3]").should("not.exist");
-                        cy.get("[data-cy=collection-version-browser-select-1]").click();
-                    });
-                // Navigate back to overview tab
-                cy.doMPVTabSelect("Overview");
-                cy.get("[data-cy=details-element]").should("contain", "This is an old version");
-                cy.get("[data-cy=read-only-icon]").should("exist");
-                cy.get("[data-cy=collection-version-number]").should("contain", "1");
-                cy.get("[data-cy=collection-details-card]").should("contain", colName);
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
-
-                // Check that only old collection action are available on toolbar
-                cy.get('[data-title="Restore version"]').should('exist');
-                cy.get('[data-title="Add to favorites"]').should('not.exist');
-
-                // Click on "head version" link, confirm that it's the latest version.
-                cy.doMPVTabSelect("Overview");;
-                cy.get("[data-cy=details-element]").contains("head version").click();
-                // Navigate back to overview after changing versions
-                cy.doMPVTabSelect("Overview");
-                cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
-                cy.get("[data-cy=read-only-icon]").should("not.exist");
-                cy.get("[data-cy=collection-version-number]").should("contain", "2");
-                cy.get("[data-cy=collection-details-card]").should("contain", colName);
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").should("not.contain", "foo").and("contain", "bar");
-
-                // Check that old collection action isn't available on context menu
-                cy.get('[data-title="Restore version"]').should('not.exist');
-
-                // Make another change, confirm new version.
-                cy.get('[data-title="Edit collection"]').click();
-                cy.get("[data-cy=form-dialog]")
-                    .should("contain", "Edit Collection")
-                    .within(() => {
-                        // appends some text
-                        cy.get("input").first().type(" renamed");
-                    });
-                cy.get("[data-cy=form-submit-btn]").click();
-                cy.doMPVTabSelect("Overview");;
-                cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
-                cy.get("[data-cy=read-only-icon]").should("not.exist");
-                cy.get("[data-cy=collection-version-number]").should("contain", "3");
-                cy.get("[data-cy=collection-details-card]").should("contain", colName + " renamed");
-                cy.get("[data-cy=collection-version-browser-select-3]").should("contain", "3").and("contain", "3 B");
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").should("not.contain", "foo").and("contain", "bar");
-
-                // Check context menus on version browser
-                cy.waitForDom();
-                cy.waitForDom();
-                cy.get("[data-cy=collection-version-browser-select-3]").rightclick();
-                cy.get("[data-cy=context-menu]")
-                    .should("contain", "Add to favorites")
-                    .and("contain", "Make a copy")
-                    .and("contain", "Edit collection");
-                cy.get("body").click();
-                // (and now an old version...)
-                cy.get("[data-cy=collection-version-browser-select-1]").rightclick();
-                cy.get("[data-cy=context-menu]")
-                    .should("not.contain", "Add to favorites")
-                    .and("contain", "Make a copy")
-                    .and("not.contain", "Edit collection");
-                cy.get("body").click();
-
-
-                // Restore first version
-                cy.get("[data-cy=collection-version-browser]").within(() => {
-                    cy.get("[data-cy=collection-version-browser-select-1]").click();
-                });
-                cy.get('[data-title="Restore version"]').click();
-                cy.get("[data-cy=confirmation-dialog]").should("contain", "Restore version");
-                cy.get("[data-cy=confirmation-dialog-ok-btn]").click();
-                // Navigate back to overview after changing versions
-                cy.doMPVTabSelect("Overview");
-                cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
-                cy.get("[data-cy=collection-version-number]").should("contain", "4");
-                cy.get("[data-cy=collection-details-card]").should("contain", colName);
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
+        // Click on version number, check version browser. Click on past version.
+        cy.get("[data-cy=collection-version-browser]").should("not.exist");
+        cy.get("[data-cy=collection-version-number]").contains("2").click();
+        cy.get("[data-cy=collection-version-browser]")
+            .should("contain", "Nr")
+            .and("contain", "Size")
+            .and("contain", "Date")
+            .within(() => {
+                // Version 1: 6 bytes in size
+                cy.get("[data-cy=collection-version-browser-select-1]")
+                    .should("contain", "1")
+                    .and("contain", "6 B")
+                    .and("contain", adminUser.user.full_name);
+                // Version 2: 3 bytes in size (one file removed)
+                cy.get("[data-cy=collection-version-browser-select-2]")
+                    .should("contain", "2")
+                    .and("contain", "3 B")
+                    .and("contain", activeUser.user.full_name);
+                cy.get("[data-cy=collection-version-browser-select-3]").should("not.exist");
+                cy.get("[data-cy=collection-version-browser-select-1]").click();
             });
+        // Navigate back to overview tab
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=details-element]").should("contain", "This is an old version");
+        cy.get("[data-cy=read-only-icon]").should("exist");
+        cy.get("[data-cy=collection-version-number]").should("contain", "1");
+        cy.get("[data-cy=collection-details-card]").should("contain", colName);
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
+
+        // Check that only old collection action are available on toolbar
+        cy.get('[data-title="Restore version"]').should('exist');
+        cy.get('[data-title="Add to favorites"]').should('not.exist');
+
+        // Click on "head version" link, confirm that it's the latest version.
+        cy.doMPVTabSelect("Overview");;
+        cy.get("[data-cy=details-element]").contains("head version").click();
+        // Navigate back to overview after changing versions
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
+        cy.get("[data-cy=read-only-icon]").should("not.exist");
+        cy.get("[data-cy=collection-version-number]").should("contain", "2");
+        cy.get("[data-cy=collection-details-card]").should("contain", colName);
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("not.contain", "foo").and("contain", "bar");
+
+        // Check that old collection action isn't available on context menu
+        cy.get('[data-title="Restore version"]').should('not.exist');
+
+        // Make another change, confirm new version.
+        cy.get('[data-title="Edit collection"]').click();
+        cy.get("[data-cy=form-dialog]")
+            .should("contain", "Edit Collection")
+            .within(() => {
+                // appends some text
+                cy.get("input").first().type(" renamed");
+            });
+        cy.get("[data-cy=form-submit-btn]").click();
+        cy.doMPVTabSelect("Overview");;
+        cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
+        cy.get("[data-cy=read-only-icon]").should("not.exist");
+        cy.get("[data-cy=collection-version-number]").should("contain", "3");
+        cy.get("[data-cy=collection-details-card]").should("contain", colName + " renamed");
+        cy.get("[data-cy=collection-version-browser-select-3]").should("contain", "3").and("contain", "3 B");
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("not.contain", "foo").and("contain", "bar");
+
+        // Check context menus on version browser
+        cy.get("[data-cy=collection-version-browser-select-3]").rightclick();
+        cy.get("[data-cy=context-menu]")
+            .should("contain", "Add to favorites")
+            .and("contain", "Make a copy")
+            .and("contain", "Edit collection");
+        cy.get("body").click();
+        // (and now an old version...)
+        cy.get("[data-cy=collection-version-browser-select-1]").rightclick();
+        cy.get("[data-cy=context-menu]")
+            .should("not.contain", "Add to favorites")
+            .and("contain", "Make a copy")
+            .and("not.contain", "Edit collection");
+        cy.get("body").click();
+
+        // Restore first version
+        cy.get("[data-cy=collection-version-browser] [data-cy=collection-version-browser-select-1]").click();
+        cy.get('[data-title="Restore version"]').click();
+        cy.get("[data-cy=confirmation-dialog]").should("contain", "Restore version");
+        cy.get("[data-cy=confirmation-dialog-ok-btn]").click();
+        // Navigate back to overview after changing versions
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
+        cy.get("[data-cy=collection-version-number]").should("contain", "4");
+        cy.get("[data-cy=collection-details-card]").should("contain", colName);
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
     });
 
     it("copies selected files into new collection", () => {
@@ -920,29 +880,25 @@ describe("Collection panel tests", function () {
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        })
-            .as("collection")
-            .then(function () {
-                // Visit collection, check basic information
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.collection.uuid}`);
+        }).as("sourceCollection");
 
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").within(() => {
-                    cy.get("input[type=checkbox]").first().click();
-                });
+        // Visit collection, check basic information
+        cy.loginAs(activeUser);
+        cy.get("@sourceCollection").then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
 
-                cy.get("[data-cy=collection-files-panel-options-btn]").click();
-                cy.get("[data-cy=context-menu]").contains("Copy selected into new collection").click();
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
 
-                cy.get("[data-cy=form-dialog]").contains("Projects").click();
+        cy.get("[data-cy=collection-files-panel-options-btn]").click();
+        cy.get("[data-cy=context-menu]").contains("Copy selected into new collection").click();
 
-                cy.get("[data-cy=form-submit-btn]").click();
+        cy.get("[data-cy=form-dialog]").contains("Projects").click();
+        cy.get("[data-cy=form-submit-btn]").click();
 
-                goToCollectionByName(`Files extracted from: ${this.collection.name}`, activeUser.token);
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
-            });
+        cy.get("@sourceCollection")
+            .then(oldColl => goToCollectionByName(`Files extracted from: ${oldColl.name}`, activeUser.token));
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
     });
 
     it("copies selected files into existing collection", () => {
@@ -960,31 +916,30 @@ describe("Collection panel tests", function () {
             manifest_text: "",
         }).as("destinationCollection");
 
-        cy.getAll("@sourceCollection", "@destinationCollection").then(function ([sourceCollection, destinationCollection]) {
-            // Visit collection, check basic information
-            cy.loginAs(activeUser);
-            cy.goToPath(`/collections/${sourceCollection.uuid}`);
+        cy.loginAs(activeUser);
+        // Visit collection, check basic information
+        cy.get("@sourceCollection").then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
 
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").within(() => {
-                cy.get("input[type=checkbox]").first().click();
-            });
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
 
-            cy.get("[data-cy=collection-files-panel-options-btn]").click();
-            cy.get("[data-cy=context-menu]").contains("Copy selected into existing collection").click();
+        cy.get("[data-cy=collection-files-panel-options-btn]").click();
+        cy.get("[data-cy=context-menu]").contains("Copy selected into existing collection").click();
 
-            cy.get("[data-cy=form-dialog]").contains(destinationCollection.name).click();
+        cy.get("@destinationCollection")
+            .its("name")
+            .then(destName => cy.get("[data-cy=form-dialog]").contains(destName).click());
 
-            cy.get("[data-cy=form-submit-btn]").click();
-            cy.wait(2000);
+        cy.get("[data-cy=form-submit-btn]").click();
 
-            cy.goToPath(`/collections/${destinationCollection.uuid}`);
+        cy.get("@destinationCollection").then(destinationCollection => cy.goToPath(`/collections/${destinationCollection.uuid}`));
 
-            cy.doMPVTabSelect("Overview");;
-            cy.get("main").contains(destinationCollection.name).should("exist");
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
-        });
+        cy.doMPVTabSelect("Overview");;
+        cy.get("@destinationCollection")
+            .its("name")
+            .then(destName => cy.get("main").contains(destName).should("exist"));
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", "bar");
     });
 
     it("copies selected files into separate collections", () => {
@@ -995,118 +950,103 @@ describe("Collection panel tests", function () {
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
         }).as("sourceCollection");
 
-        cy.getAll("@sourceCollection").then(function ([sourceCollection]) {
-            // Visit collection, check basic information
-            cy.loginAs(activeUser);
-            cy.goToPath(`/collections/${sourceCollection.uuid}`);
+        // Visit collection, check basic information
+        cy.loginAs(activeUser);
+        cy.get("@sourceCollection").then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
 
-            // Select both files
-            cy.waitForDom()
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]")
-                .within(() => {
-                    cy.get("input[type=checkbox]").first().click();
-                    cy.get("input[type=checkbox]").last().click();
-                });
+        // Select both files
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
+        cy.get("[data-cy=collection-files-panel] input[type=checkbox]").last().click();
 
-            // Copy to separate collections
-            cy.get("[data-cy=collection-files-panel-options-btn]").click();
-            cy.get("[data-cy=context-menu]").contains("Copy selected into separate collections").click();
-            cy.get("[data-cy=form-dialog]").contains("Projects").click();
-            cy.get("[data-cy=form-submit-btn]").click();
+        // Copy to separate collections
+        cy.get("[data-cy=collection-files-panel-options-btn]").click();
+        cy.get("[data-cy=context-menu]").contains("Copy selected into separate collections").click();
+        cy.get("[data-cy=form-dialog]").contains("Projects").click();
+        cy.get("[data-cy=form-submit-btn]").click();
 
-            // Verify created collections
-            goToCollectionByName(`File copied from collection ${sourceCollection.name}/foo`, activeUser.token);
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").and("contain", "foo");
-            goToCollectionByName(`File copied from collection ${sourceCollection.name}/bar`, activeUser.token);
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
+        // Verify created collections
+        cy.get("@sourceCollection")
+            .then(oldColl => goToCollectionByName(`File copied from collection ${oldColl.name}/foo`, activeUser.token));
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='foo']").should("be.visible");
 
-            // Verify separate collection menu items not present when single file selected
-            // Wait for dom for collection to re-render
-            cy.waitForDom()
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]")
-                .within(() => {
-                    cy.get("input[type=checkbox]").first().click();
-                });
-            cy.get("[data-cy=collection-files-panel-options-btn]").click();
-            cy.get("[data-cy=context-menu]").should("not.contain", "Copy selected into separate collections");
-            cy.get("[data-cy=context-menu]").should("not.contain", "Move selected into separate collections");
-        });
+        cy.get("@sourceCollection")
+            .then(oldColl => goToCollectionByName(`File copied from collection ${oldColl.name}/bar`, activeUser.token));
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='bar']").should("be.visible");
+
+        // Verify separate collection menu items not present when single file selected
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel] input[type=checkbox]")
+            .first().click();
+        cy.get("[data-cy=collection-files-panel-options-btn]").click();
+        cy.get("[data-cy=context-menu]")
+            .should("not.contain", "Copy selected into separate collections")
+            .and("not.contain", "Move selected into separate collections");
     });
 
     it("moves selected files into new collection", () => {
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
             name: `Test Collection ${Math.floor(Math.random() * 999999)}`,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        })
-            .as("collection")
-            .then(function () {
-                // Visit collection, check basic information
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.collection.uuid}`);
+        }).as("testCollection")
+            .then(testCollection => cy.goToPath(`/collections/${testCollection.uuid}`));
 
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").within(() => {
-                    cy.get("input[type=checkbox]").first().click();
-                });
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
 
-                cy.get("[data-cy=collection-files-panel-options-btn]").click();
-                cy.get("[data-cy=context-menu]").contains("Move selected into new collection").click();
+        cy.get("[data-cy=collection-files-panel-options-btn]").click();
+        cy.get("[data-cy=context-menu]").contains("Move selected into new collection").click();
 
-                cy.get("[data-cy=form-dialog]").contains("Projects").click();
+        cy.get("[data-cy=form-dialog]").contains("Projects").click();
 
-                cy.get("[data-cy=form-submit-btn]").click();
+        cy.get("[data-cy=form-submit-btn]").click();
 
-                goToCollectionByName(`Files moved from: ${this.collection.name}`, activeUser.token);
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
-            });
+        cy.get("@testCollection").then(oldColl => goToCollectionByName(`Files moved from: ${oldColl.name}`, activeUser.token));
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
     });
 
     it("moves selected files into existing collection", () => {
+        const srcName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
+        const dstName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
+
         cy.createCollection(adminUser.token, {
-            name: `Test Collection ${Math.floor(Math.random() * 999999)}`,
+            name: srcName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        }).as("sourceCollection");
+        }).as("srcCollection");
 
         cy.createCollection(adminUser.token, {
-            name: `Destination Collection ${Math.floor(Math.random() * 999999)}`,
+            name: dstName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: "",
-        }).as("destinationCollection");
+        }).as("dstCollection");
 
-        cy.getAll("@sourceCollection", "@destinationCollection").then(function ([sourceCollection, destinationCollection]) {
-            // Visit collection, check basic information
-            cy.loginAs(activeUser);
-            cy.goToPath(`/collections/${sourceCollection.uuid}`);
+        cy.loginAs(activeUser);
+        cy.get("@srcCollection").then(srcCollection => cy.goToPath(`/collections/${srcCollection.uuid}`));
 
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").within(() => {
-                cy.get("input[type=checkbox]").first().click();
-            });
+        cy.doMPVTabSelect("Files");
+        // FIXME: implicitly relying on "bar" being first.
+        cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
 
-            cy.get("[data-cy=collection-files-panel-options-btn]").click();
-            cy.get("[data-cy=context-menu]").contains("Move selected into existing collection").click();
+        cy.get("[data-cy=collection-files-panel-options-btn]").click();
+        cy.get("[data-cy=context-menu]").contains("Move selected into existing collection").click();
 
-            cy.get("[data-cy=form-dialog]").contains(destinationCollection.name).click();
+        cy.get("[data-cy=form-dialog]").contains(dstName).click();
+        cy.get("[data-cy=form-submit-btn]").click();
 
-            cy.get("[data-cy=form-submit-btn]").click();
-            cy.wait(2000);
+        cy.get("@dstCollection").then(dstCollection => cy.goToPath(`/collections/${dstCollection.uuid}`));
 
-            cy.goToPath(`/collections/${destinationCollection.uuid}`);
-
-            cy.get("main").contains(destinationCollection.name).should("exist");
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
-        });
+        cy.get("main").contains(dstName).should("exist");
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", "bar");
     });
 
     it("moves selected files into separate collections", () => {
@@ -1117,34 +1057,32 @@ describe("Collection panel tests", function () {
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
         }).as("sourceCollection");
 
-        cy.getAll("@sourceCollection").then(function ([sourceCollection]) {
-            // Visit collection, check basic information
-            cy.loginAs(activeUser);
-            cy.goToPath(`/collections/${sourceCollection.uuid}`);
-            cy.doMPVTabSelect("Files");
+        // Visit collection, check basic information
+        cy.loginAs(activeUser);
+        cy.get("@sourceCollection").then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
 
-            // Select both files
-            cy.get("[data-cy=collection-files-panel]").within(() => {
-                cy.get("input[type=checkbox]").first().click();
-                cy.get("input[type=checkbox]").last().click();
-            });
-
-            // Move to separate collections
-            cy.get("[data-cy=collection-files-panel-options-btn]").click();
-            cy.get("[data-cy=context-menu]").contains("Move selected into separate collections").click();
-            cy.get("[data-cy=form-dialog]").contains("Projects").click();
-            cy.get("[data-cy=form-submit-btn]").click();
-            cy.get("[data-cy=form-dialog]").should("not.exist", { timeout: 10000 });
-
-            // Verify created collections
-            goToCollectionByName(`File moved from collection ${sourceCollection.name}/foo`, activeUser.token);
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='foo']").should("be.visible");
-
-            goToCollectionByName(`File moved from collection ${sourceCollection.name}/bar`, activeUser.token);
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='bar']").should("be.visible");
+        cy.doMPVTabSelect("Files");
+        // Select both files
+        cy.get("[data-cy=collection-files-panel]").within(() => {
+            cy.get("input[type=checkbox]").first().click();
+            cy.get("input[type=checkbox]").last().click();
         });
+
+        // Move to separate collections
+        cy.get("[data-cy=collection-files-panel-options-btn]").click();
+        cy.get("[data-cy=context-menu]").contains("Move selected into separate collections").click();
+        cy.get("[data-cy=form-dialog]").contains("Projects").click();
+        cy.get("[data-cy=form-submit-btn]").click();
+        cy.get("[data-cy=form-dialog]").should("not.exist");
+
+        // Verify created collections
+        cy.get("@sourceCollection").then(oldColl => goToCollectionByName(`File moved from collection ${oldColl.name}/foo`, activeUser.token));
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='foo']").should("be.visible");
+
+        cy.get("@sourceCollection").then(oldColl => goToCollectionByName(`File moved from collection ${oldColl.name}/bar`, activeUser.token));
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='bar']").should("be.visible");
     });
 
     it("creates new collection with properties on home project", function () {
@@ -1166,12 +1104,8 @@ describe("Collection panel tests", function () {
             .and("contain", "foo")
             .and("contain", "bar")
             .within(() => {
-                cy.get("[data-cy=parent-field]").within(() => {
-                    cy.get("input").should("have.value", "Home project");
-                });
-                cy.get("[data-cy=name-field]").within(() => {
-                    cy.get("input").type(collName);
-                });
+                cy.get("[data-cy=parent-field] input").should("have.value", "Home project");
+                cy.get("[data-cy=name-field] input").type(collName);
                 cy.get("[data-cy=checkbox-foo]").click();
             });
 
@@ -1179,9 +1113,7 @@ describe("Collection panel tests", function () {
         // Key: Color (IDTAGCOLORS) - Value: Magenta (IDVALCOLORS3)
         cy.get("[data-cy=form-dialog]").should("not.contain", "Color: Magenta");
         cy.get("[data-cy=resource-properties-form]").within(() => {
-            cy.get("[data-cy=property-field-key]").within(() => {
-                cy.get("input").type("Color");
-            });
+            cy.get("[data-cy=property-field-key] input").type("Color");
             cy.get("[data-cy=property-field-value]").click().within(() => {
                 cy.get("input").type("Magenta");
             });
@@ -1217,10 +1149,9 @@ describe("Collection panel tests", function () {
             filters: `[["name", "=", "${collName}"]]`,
         })
             .its("body.items")
-            .as("collections")
-            .then(function () {
-                expect(this.collections).to.have.lengthOf(1);
-                expect(this.collections[0].properties["IDTAGCOLORS"]).to.deep.equal(["IDVALCOLORS3"]);
+            .then(collArray => {
+                expect(collArray).to.have.lengthOf(1);
+                expect(collArray[0].properties["IDTAGCOLORS"]).to.deep.equal(["IDVALCOLORS3"]);
             });
     });
 

--- a/services/workbench2/cypress/e2e/collection.cy.js
+++ b/services/workbench2/cypress/e2e/collection.cy.js
@@ -8,6 +8,9 @@ require('cypress-plugin-tab');
 // It can be tricky to mimick the user's search for a collection by its known
 // (and unique) name, which can be noisy, time consuming, and a bit flaky. We
 // locate the collection by API directly and jump to it.
+// NOTE: To use after some collection-creating user action, it's a good idea to
+// add a "barrier" assertion (e.g., disappeared form dialog, snackbar with a
+// certain message, etc.) before calling.
 function goToCollectionByName(collectionName, token) {
     return cy.doRequest("GET", "/arvados/v1/collections", null, {
         filters: JSON.stringify([["name", "=", collectionName]]),
@@ -21,6 +24,10 @@ function goToCollectionByName(collectionName, token) {
             const uuid = response.body.items[0].uuid;
             return cy.goToPath(`/collections/${uuid}`);
         });
+}
+
+function randomName(prefix = "Test collection ") {  // note the ending space
+    return `${prefix}${Math.floor(Math.random() * 999999)}`;
 }
 
 describe("Collection panel tests", function () {
@@ -47,16 +54,16 @@ describe("Collection panel tests", function () {
     });
 
     it("allows to download mountain duck config for a collection", () => {
+        cy.loginAs(activeUser);
         // Creates the collection using the admin token so we can set up
         // a bogus manifest text without block signatures.
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: randomName(),
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
         })
             .as("testCollection")
             .then(function (testCollection) {
-                cy.loginAs(activeUser);
                 cy.goToPath(`/collections/${testCollection.uuid}`);
 
                 cy.get('[data-title="Open with 3rd party client"]').click();
@@ -94,9 +101,9 @@ describe("Collection panel tests", function () {
     });
 
     it("attempts to use a preexisting name creating or updating a collection", function () {
-        const name = `Test collection ${Math.floor(Math.random() * 999999)}`;
+        const collName = randomName();
         cy.createCollection(adminUser.token, {
-            name: name,
+            name: collName,
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
         });
@@ -110,13 +117,12 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=form-dialog]")
             .should("contain", "New collection")
             .within(() => {
-                cy.get("[data-cy=name-field] input").type(name);
+                cy.get("[data-cy=name-field] input").type(collName);
                 cy.get("[data-cy=form-submit-btn]").click();
             });
         // Error message should display, allowing editing the name
         cy.get("[data-cy=form-dialog]")
-            .should("exist")
-            .and("contain", "Collection with the same name already exists")
+            .should("contain", "Collection with the same name already exists")
             .within(() => {
                 cy.get("[data-cy=name-field] input").type(" renamed");
                 cy.get("[data-cy=form-submit-btn]").click();
@@ -127,130 +133,120 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=form-dialog]")
             .should("contain", "Edit Collection")
             .within(() => {
-                cy.get("[data-cy=name-field] input").type("{selectall}{backspace}").type(name);
+                cy.get("[data-cy=name-field] input").type("{selectall}{backspace}").type(collName);
                 cy.get("[data-cy=form-submit-btn]").click();
             });
         cy.get("[data-cy=form-dialog]").should("exist").and("contain", "Collection with the same name already exists");
     });
 
     it("uses the property editor (from edit dialog) with vocabulary terms", function () {
+        const collName = randomName();
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: collName,
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
         })
             .as("testCollection")
-            .then(function () {
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.testCollection.uuid}`);
+            .then((testCollection) => cy.goToPath(`/collections/${testCollection.uuid}`));
 
-                // Verify collection name
-                cy.get("[data-cy=collection-details-card").should("contain", this.testCollection.name);
-                // Open overview tab
-                cy.doMPVTabSelect("Overview");
-                // Verify property not present
-                cy.get("[data-cy=resource-properties]").should("not.contain", "Color: Magenta");
+        // Verify collection name
+        cy.get("[data-cy=collection-details-card").should("contain", collName);
+        // Open overview tab
+        cy.doMPVTabSelect("Overview");
+        // Verify property not present
+        cy.get("[data-cy=resource-properties]").should("not.contain", "Color: Magenta");
 
-                cy.get('[data-title="Edit collection"]').click();
-                cy.get("[data-cy=form-dialog]").should("contain", "Properties");
+        cy.get('[data-title="Edit collection"]').click();
+        cy.get("[data-cy=form-dialog]").should("contain", "Properties");
 
-                // Key: Color (IDTAGCOLORS) - Value: Magenta (IDVALCOLORS3)
-                cy.get("[data-cy=resource-properties-form]").within(() => {
-                    cy.get("[data-cy=property-field-key]").within(() => {
-                        cy.get("input").type("Color");
-                    });
-                    cy.get("[data-cy=property-field-value]").click().within(() => {
-                        cy.get("input").type("Magenta");
-                    });
-                    cy.get("[data-cy=property-add-btn]").click();
-                });
-                // Confirm proper vocabulary labels are displayed on the UI.
-                cy.get("[data-cy=form-dialog]").should("contain", "Color: Magenta");
-                cy.get("[data-cy=form-dialog]").contains("Save").click();
-                cy.get("[data-cy=form-dialog]").should("not.exist");
-                // Confirm proper vocabulary IDs were saved on the backend.
-                cy.doRequest("GET", `/arvados/v1/collections/${this.testCollection.uuid}`)
-                    .its("body")
-                    .as("collection")
-                    .then(function () {
-                        expect(this.collection.properties.IDTAGCOLORS).to.deep.equal(["IDVALCOLORS3"]);
-                    });
-                // Confirm the property is displayed on the UI.
-                cy.get("[data-cy=resource-properties").should("contain", "Color: Magenta");
+        // Key: Color (IDTAGCOLORS) - Value: Magenta (IDVALCOLORS3)
+        cy.get("[data-cy=resource-properties-form]").within(() => {
+            cy.get("[data-cy=property-field-key] input").type("Color");
+            cy.get("[data-cy=property-field-value]").click().within(() => {
+                cy.get("input").type("Magenta");
             });
+            cy.get("[data-cy=property-add-btn]").click();
+        });
+        // Confirm proper vocabulary labels are displayed on the UI.
+        cy.get("[data-cy=form-dialog]")
+            .should("contain", "Color: Magenta")
+            .contains("Save").click();
+        cy.get("[data-cy=form-dialog]").should("not.exist");
+        // Confirm proper vocabulary IDs were saved on the backend.
+        cy.get("@testCollection")
+            .then((testCollection) => cy.getCollection(activeUser.token, testCollection.uuid))
+            .its("properties")
+            .should("deep.include", { IDTAGCOLORS: ["IDVALCOLORS3"] });
+        // Confirm the property is displayed on the UI.
+        cy.get("[data-cy=resource-properties").should("contain", "Color: Magenta");
     });
 
     it("uses the editor (from details panel) with vocabulary terms", function () {
+        const collName = randomName();
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: collName,
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
         })
             .as("testCollection")
-            .then(function () {
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.testCollection.uuid}`);
+            .then((testCollection) => cy.goToPath(`/collections/${this.testCollection.uuid}`));
 
-                // Verify collection name
-                cy.get("[data-cy=collection-details-card")
-                    .should("contain", this.testCollection.name);
+        // Verify collection name
+        cy.get("[data-cy=collection-details-card").should("contain", collName);
 
-                // Open overview tab
-                cy.doMPVTabSelect("Overview");
+        // Open overview tab
+        cy.doMPVTabSelect("Overview");
 
-                // Verify properties not present
-                cy.get("[data-cy=resource-properties]")
-                    .and("not.contain", "Color: Magenta")
-                    .and("not.contain", "Size: S");
-                cy.get("[data-title='View details']").click();
+        // Verify properties not present
+        cy.get("[data-cy=resource-properties]")
+            .and("not.contain", "Color: Magenta")
+            .and("not.contain", "Size: S");
+        cy.get("[data-title='View details']").click();
 
-                cy.get("[data-cy=details-panel]").within(() => {
-                    cy.get("[data-cy=details-panel-edit-btn]").click();
-                });
-                cy.get("[data-cy=form-dialog").contains("Edit Collection");
+        cy.get("[data-cy=details-panel] [data-cy=details-panel-edit-btn]").click();
+        cy.get("[data-cy=form-dialog").should("contain", "Edit Collection");
 
-                // Key: Color (IDTAGCOLORS) - Value: Magenta (IDVALCOLORS3)
-                cy.get("[data-cy=resource-properties-form]").within(() => {
-                    cy.get("[data-cy=property-field-key]").within(() => {
-                        cy.get("input").type("Color");
-                    });
-                    cy.get("[data-cy=property-field-value]").click().within(() => {
-                        cy.get("input").type("Magenta");
-                    });
-                    cy.get("[data-cy=property-add-btn]").click();
-                });
-                // Confirm proper vocabulary labels are displayed on the UI.
-                cy.get("[data-cy=form-dialog]").should("contain", "Color: Magenta");
-
-                // Case-insensitive on-blur auto-selection test
-                // Key: Size (IDTAGSIZES) - Value: Small (IDVALSIZES2)
-                cy.get("[data-cy=resource-properties-form]").within(() => {
-                    cy.get("[data-cy=property-field-key] input").type("sIzE");
-                    cy.get("[data-cy=property-field-value]").click().within(() => {
-                        cy.get("input").type("sMaLL{enter}");
-                    });
-                    cy.get("[data-cy=property-add-btn]").click();
-                });
-                // Confirm proper vocabulary labels are displayed on the UI.
-                cy.get("[data-cy=form-dialog]").should("contain", "Size: S");
-
-                cy.get("[data-cy=form-dialog]").contains("Save").click();
-                cy.get("[data-cy=form-dialog]").should("not.exist");
-
-                // Confirm proper vocabulary IDs were saved on the backend.
-                cy.doRequest("GET", `/arvados/v1/collections/${this.testCollection.uuid}`)
-                    .its("body")
-                    .as("collection")
-                    .then(function () {
-                        expect(this.collection.properties.IDTAGCOLORS).to.deep.equal(["IDVALCOLORS3"]);
-                        expect(this.collection.properties.IDTAGSIZES).to.deep.equal(["IDVALSIZES2"]);
-                    });
-
-                // Confirm properties display on the UI.
-                cy.get("[data-cy=resource-properties]")
-                    .should("contain", "Color: Magenta")
-                    .and("contain", "Size: S");
+        // Key: Color (IDTAGCOLORS) - Value: Magenta (IDVALCOLORS3)
+        cy.get("[data-cy=resource-properties-form]").within(() => {
+            cy.get("[data-cy=property-field-key] input").type("Color");
+            cy.get("[data-cy=property-field-value]").click().within(() => {
+                cy.get("input").type("Magenta");
             });
+            cy.get("[data-cy=property-add-btn]").click();
+        });
+        // Confirm proper vocabulary labels are displayed on the UI.
+        cy.get("[data-cy=form-dialog]").should("contain", "Color: Magenta");
+
+        // Case-insensitive on-blur auto-selection test
+        // Key: Size (IDTAGSIZES) - Value: Small (IDVALSIZES2)
+        cy.get("[data-cy=resource-properties-form]").within(() => {
+            cy.get("[data-cy=property-field-key] input").type("sIzE");
+            cy.get("[data-cy=property-field-value]").click().within(() => {
+                cy.get("input").type("sMaLL{enter}");
+            });
+            cy.get("[data-cy=property-add-btn]").click();
+        });
+        // Confirm proper vocabulary labels are displayed on the UI.
+        cy.get("[data-cy=form-dialog]")
+            .should("contain", "Size: S")
+            .contains("Save").click();
+        cy.get("[data-cy=form-dialog]").should("not.exist");
+
+        // Confirm proper vocabulary IDs were saved on the backend.
+        cy.get("@testCollection")
+            .then((testCollection) => cy.getCollection(activeUser.token, testCollection.uuid))
+            .its("properties")
+            .should("deep.include", {
+                IDTAGCOLORS: ["IDVALCOLORS3"],
+                IDTAGSIZES: ["IDVALSIZES2"]
+            });
+
+        // Confirm properties display on the UI.
+        cy.get("[data-cy=resource-properties]")
+            .should("contain", "Color: Magenta")
+            .and("contain", "Size: S");
     });
 
     it("shows collection by URL", function () {
@@ -314,7 +310,12 @@ describe("Collection panel tests", function () {
             });
 
             // Check for the read-only icon
-            cy.get("[data-cy=read-only-icon]").should(`${isWritable ? "not." : ""}exist`);
+            if (isWritable) {
+                cy.get("[data-cy=read-only-icon]").should("not.exist");
+            } else {
+                cy.get("[data-cy=read-only-icon]").should("be.visible");
+            }
+
             // Check that both read and write operations are available on
             // the 'More options' menu.
             cy.get("[data-cy=collection-details-card]").within(() => {
@@ -376,10 +377,10 @@ describe("Collection panel tests", function () {
 
         cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: randomName(),
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
-        }).then(collection => cy.goToPath(`/collections/${collection.uuid}`));
+        }).then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         const names = [
             "bar", // initial name already set
@@ -423,10 +424,10 @@ describe("Collection panel tests", function () {
     it("renames a file to a different directory", function () {
         cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: randomName(),
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
-        }).then(collection => cy.goToPath(`/collections/${collection.uuid}`));
+        }).then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         cy.doMPVTabSelect("Files");
         ["subdir", "G%C3%BCnter's%20file", "table%&?*2"].forEach(subdir => {
@@ -475,13 +476,13 @@ describe("Collection panel tests", function () {
     it("shows collection owner", () => {
         cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: randomName(),
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
-        }).then(collection => cy.goToPath(`/collections/${collection.uuid}`));
+        }).then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         cy.doMPVTabSelect("Overview");
-        cy.get("[data-cy=details-element]").contains(activeUser.user.full_name);
+        cy.get("[data-cy=details-element]").should("contain", activeUser.user.full_name);
     });
 
     it("tries to rename a file with illegal names", function () {
@@ -497,11 +498,10 @@ describe("Collection panel tests", function () {
 
         cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: randomName(),
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
-        })
-            .then(testCollection => cy.goToPath(`/collections/${testCollection.uuid}`));
+        }).then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         cy.doMPVTabSelect("Files");
         illegalNamesFromUI.forEach(([name, errMsg]) => {
@@ -522,133 +522,120 @@ describe("Collection panel tests", function () {
     });
 
     it("can correctly display old versions", function () {
-        const colName = `Versioned Collection ${Math.floor(Math.random() * 999999)}`;
-        let colUuid = "";
-        let oldVersionUuid = "";
-        // Make sure no other collections with this name exist
-        cy.doRequest("GET", "/arvados/v1/collections", null, {
-            filters: `[["name", "=", "${colName}"]]`,
-            include_old_versions: true,
-        })
-            .its("body.items")
-            .as("collections")
-            .then(function () {
-                expect(this.collections).to.be.empty;
-            });
+        const collName = randomName("Versioned Collection ");
+        cy.loginAs(activeUser);
+
         cy.createCollection(adminUser.token, {
-            name: colName,
+            name: collName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
         })
-            .as("originalVersion")
-            .then(function () {
-                // Change the file name to create a new version.
-                cy.updateCollection(adminUser.token, this.originalVersion.uuid, {
-                    manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo\n",
-                });
-                colUuid = this.originalVersion.uuid;
-            });
-        // Confirm that there are 2 versions of the collection
-        cy.doRequest("GET", "/arvados/v1/collections", null, {
-            filters: `[["name", "=", "${colName}"]]`,
-            include_old_versions: true,
-        })
-            .its("body.items")
-            .as("collections")
-            .then(function () {
-                expect(this.collections).to.have.lengthOf(2);
-                this.collections.map(function (aCollection) {
-                    expect(aCollection.current_version_uuid).to.equal(colUuid);
-                    if (aCollection.uuid !== aCollection.current_version_uuid) {
-                        oldVersionUuid = aCollection.uuid;
-                    }
-                });
-                // Check the old version displays as what it is.
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${oldVersionUuid}`);
-                cy.doMPVTabSelect("Overview");
+            // Change the file name to create a new version.
+            .then((collection) => cy.updateCollection(adminUser.token, collection.uuid, {
+                manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo\n",
+            }))
+            // Get old version.
+            .then((collection) => cy.doRequest("GET", "/arvados/v1/collections", null, {
+                filters: JSON.stringify([
+                    ["current_version_uuid", "=", collection.uuid],
+                    ["version", "=", 1],
+                ]),
+                include_old_versions: true,
+                limit: "1",
+                select: JSON.stringify(["uuid"]),
+                count: "none",
+            }, activeUser.token, true))
+            .its("body.items.0.uuid")
+            // Go to old version.
+            .then((oldVersionUuid) => cy.goToPath(`/collections/${oldVersionUuid}`));
 
-                cy.get("[data-cy=details-element]").should("contain", "This is an old version");
-                cy.get("[data-cy=read-only-icon]").should("exist");
-                cy.get("[data-cy=collection-details-card]").should("contain", colName);
-                cy.doMPVTabSelect("Files");
-                cy.get("[data-cy=collection-files-panel]").should("contain", "bar");
-            });
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=details-element]").should("contain", "This is an old version");
+        cy.get("[data-cy=read-only-icon]").should("be.visible");
+        cy.get("[data-cy=collection-details-card]").should("contain", collName);
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]").should("contain", "bar");
     });
 
     it("views & edits storage classes data", function () {
-        const colName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
+        cy.loginAs(activeUser);
+
         cy.createCollection(adminUser.token, {
-            name: colName,
+            name: randomName(),
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:some-file\n",
         })
-            .as("collection")
-            .then(function () {
-                expect(this.collection.storage_classes_desired).to.deep.equal(["default"]);
+            .as("testCollection")
+            .then((testCollection) => cy.goToPath(`/collections/${testCollection.uuid}`));
 
-                cy.loginAs(activeUser);
-                cy.goToPath(`/collections/${this.collection.uuid}`);
-                cy.doMPVTabSelect("Overview");
-
-                // Initial check: it should show the 'default' storage class
-                cy.get("[data-cy=details-element]")
-                    .should("contain", "Storage classes")
-                    .and("contain", "default")
-                    .and("not.contain", "foo")
-                    .and("not.contain", "bar");
-                // Edit collection: add storage class 'foo'
-                cy.get('[data-title="Edit collection"]').click();
-                cy.get("[data-cy=form-dialog]")
-                    .should("contain", "Edit Collection")
-                    .and("contain", "Storage classes")
-                    .and("contain", "default")
-                    .and("contain", "foo")
-                    .and("contain", "bar")
-                    .within(() => {
-                        cy.get("[data-cy=checkbox-foo]").click();
-                    });
-                cy.get("[data-cy=form-submit-btn]").click();
-                cy.get("[data-cy=details-element]").should("contain", "default").and("contain", "foo").and("not.contain", "bar");
-                cy.doRequest("GET", `/arvados/v1/collections/${this.collection.uuid}`)
-                    .its("body")
-                    .as("updatedCollection")
-                    .then(function () {
-                        expect(this.updatedCollection.storage_classes_desired).to.deep.equal(["default", "foo"]);
-                    });
-                // Edit collection: remove storage class 'default'
-                cy.get('[data-title="Edit collection"]').click();
-                cy.get("[data-cy=form-dialog]")
-                    .should("contain", "Edit Collection")
-                    .and("contain", "Storage classes")
-                    .and("contain", "default")
-                    .and("contain", "foo")
-                    .and("contain", "bar")
-                    .within(() => {
-                        cy.get("[data-cy=checkbox-default]").click();
-                    });
-                cy.get("[data-cy=form-submit-btn]").click();
-                cy.get("[data-cy=details-element]").should("not.contain", "default").and("contain", "foo").and("not.contain", "bar");
-                cy.doRequest("GET", `/arvados/v1/collections/${this.collection.uuid}`)
-                    .its("body")
-                    .as("updatedCollection")
-                    .then(function () {
-                        expect(this.updatedCollection.storage_classes_desired).to.deep.equal(["foo"]);
-                    });
+        cy.doMPVTabSelect("Overview");
+        // Initial check: it should show the 'default' storage class
+        cy.get("[data-cy=details-element]")
+            .should("contain", "Storage classes")
+            .and("contain", "default")
+            .and("not.contain", "foo")
+            .and("not.contain", "bar");
+        // Edit collection: add storage class 'foo'
+        cy.get('[data-title="Edit collection"]').click();
+        cy.get("[data-cy=form-dialog]")
+            .should("contain", "Edit Collection")
+            .and("contain", "Storage classes")
+            .and("contain", "default")
+            .and("contain", "foo")
+            .and("contain", "bar")
+            .within(() => {
+                cy.get("[data-cy=checkbox-foo]").click();
             });
+        cy.get("[data-cy=form-submit-btn]").click();
+        cy.get("[data-cy=details-element]")
+            .should("contain", "default")
+            .and("contain", "foo")
+            .and("not.contain", "bar");
+
+        // Storage class changes are committed.
+        cy.get("@testCollection")
+            .its("uuid")
+            .then((uuid) => cy.getCollection(activeUser.token, uuid))
+            .its("storage_classes_desired")
+            .should("deep.equal", ["default", "foo"]);
+
+        // Edit collection: remove storage class 'default'
+        cy.get('[data-title="Edit collection"]').click();
+        cy.get("[data-cy=form-dialog]")
+            .should("contain", "Edit Collection")
+            .and("contain", "Storage classes")
+            .and("contain", "default")
+            .and("contain", "foo")
+            .and("contain", "bar")
+            .within(() => {
+                cy.get("[data-cy=checkbox-default]").click();
+            });
+        cy.get("[data-cy=form-submit-btn]").click();
+        cy.get("[data-cy=details-element]")
+            .should("not.contain", "default")
+            .and("contain", "foo")
+            .and("not.contain", "bar");
+
+        // Storage class changes are committed.
+        cy.get("@testCollection")
+            .its("uuid")
+            .then((uuid) => cy.getCollection(activeUser.token, uuid))
+            .its("storage_classes_desired")
+            .should("deep.equal", ["foo"]);
     });
 
     it("moves a collection to a different project", function () {
-        const collName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
-        const projName = `Test Project ${Math.floor(Math.random() * 999999)}`;
-        const fileName = `Test_File_${Math.floor(Math.random() * 999999)}`;
+        const collName = randomName();
+        const projName = randomName("Test Project ");
+        const fileName = randomName("Test_File_");
 
         cy.createCollection(adminUser.token, {
             name: collName,
             owner_uuid: activeUser.user.uuid,
             manifest_text: `. 37b51d194a7513e45b56f6524f2d51f2+3 0:3:${fileName}\n`,
         }).as("testCollection");
+
         cy.createGroup(adminUser.token, {
             name: projName,
             group_class: "project",
@@ -676,7 +663,7 @@ describe("Collection panel tests", function () {
                 cy.get("[data-cy=projects-tree-home-tree-picker]").contains(projName).click();
             });
         cy.get("[data-cy=form-submit-btn]").click();
-        cy.get("[data-cy=snackbar]").contains("Collection has been moved");
+        cy.get("[data-cy=snackbar]").should("contain", "Collection has been moved");
         cy.get("button").contains(projName);
         // Double check that the collection is in the project
         cy.get("@testProject").then(testProject => cy.goToPath(`/projects/${testProject.uuid}`));
@@ -685,47 +672,49 @@ describe("Collection panel tests", function () {
     });
 
     it("automatically updates the collection UI contents without using the Refresh button", function () {
-        const collName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
-        cy.clock();
+        const collName = randomName();
+        cy.loginAs(activeUser);
 
         cy.createCollection(adminUser.token, {
             name: collName,
             owner_uuid: activeUser.user.uuid,
-        }).as("testCollection");
+        })
+            .its("uuid")
+            .as("testUuid")
+            .then((testUuid) => cy.goToPath(`/collections/${testUuid}`));
 
-        cy.getAll("@testCollection").then(function ([testCollection]) {
-            cy.loginAs(activeUser);
+        const files = ["foobar", "anotherFile", "", "finalName"];
+        cy.doMPVTabSelect("Files");
+        cy.get("[data-cy=collection-files-panel]")
+            .should("contain", "This collection is empty")
+            .and("not.contain", files[0]);
+        cy.get("[data-cy=collection-details-card]").should("contain", collName);
 
-            const files = ["foobar", "anotherFile", "", "finalName"];
-
-            cy.goToPath(`/collections/${testCollection.uuid}`);
-            cy.doMPVTabSelect("Files");
-            cy.get("[data-cy=collection-files-panel]").should("contain", "This collection is empty");
-            cy.get("[data-cy=collection-files-panel]").should("not.contain", files[0]);
-            cy.get("[data-cy=collection-details-card]").should("contain", collName);
-
-            files.map((fileName, i, files) => {
-                cy.updateCollection(adminUser.token, testCollection.uuid, {
-                    name: `${collName + " updated"}`,
+        cy.clock();
+        files.map((fileName, i, files) => {
+            let collNewName = `${collName} updated ${i}`;
+            cy.get("@testUuid")
+                .then((uuid) => cy.updateCollection(adminUser.token, uuid, {
+                    name: collNewName,
                     manifest_text: fileName ? `. 37b51d194a7513e45b56f6524f2d51f2+3 0:3:${fileName}\n` : "",
-                }).as("updatedCollection");
-
-                // Fast forward 15 seconds for the websocket throttle
-                cy.tick(15000);
-
-                cy.getAll("@updatedCollection").then(function ([updatedCollection]) {
-                    expect(updatedCollection.name).to.equal(`${collName + " updated"}`);
-                    cy.get("[data-cy=collection-details-card]").should("contain", updatedCollection.name);
-                    fileName
-                        ? cy.get("[data-cy=collection-files-panel]").should("contain", fileName)
-                        : cy.get("[data-cy=collection-files-panel]").should("not.contain", files[i - 1]);
+                }))
+                .then(() => {
+                    // Fast forward 15 seconds for the websocket throttle
+                    cy.tick(15000);
                 });
-            });
+            cy.get("[data-cy=collection-details-card]").should("contain", collNewName);
+            if (fileName) {
+                cy.get("[data-cy=collection-files-panel]").should("contain", fileName);
+            } else {
+                cy.get("[data-cy=collection-files-panel]")
+                    .should("contain", "This collection is empty")
+                    .and("not.contain", files[i - 1]);
+            }
         });
     });
 
     it("makes a copy of an existing collection", function () {
-        const collName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
+        const collName = randomName();
         const copyName = `Copy of: ${collName}`;
 
         cy.loginAs(activeUser);
@@ -735,7 +724,7 @@ describe("Collection panel tests", function () {
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:some-file\n",
         })
-            .then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
+            .then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").should("contain", "some-file");
@@ -746,29 +735,29 @@ describe("Collection panel tests", function () {
                 cy.get("[data-cy=projects-tree-home-tree-picker]").contains("Projects").click();
                 cy.get("[data-cy=form-submit-btn]").click();
             });
-        cy.get("[data-cy=snackbar]").contains("Collection has been copied.");
 
+        cy.get("[data-cy=snackbar]").should("contain", "Collection has been copied.");
         goToCollectionByName(copyName, activeUser.token);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").should("contain", "some-file");
     });
 
     it("uses the collection version browser to view a previous version", function () {
-        const colName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
+        const collName = randomName();
 
         cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: colName,
+            name: collName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        }).then(collection => cy.goToPath(`/collections/${collection.uuid}`));
+        }).then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         cy.doMPVTabSelect("Overview");
         cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
         cy.get("[data-cy=read-only-icon]").should("not.exist");
         cy.get("[data-cy=collection-version-number]").should("contain", "1");
-        cy.get("[data-cy=collection-details-card]").should("contain", colName);
+        cy.get("[data-cy=collection-details-card]").should("contain", collName);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
 
@@ -805,9 +794,9 @@ describe("Collection panel tests", function () {
         // Navigate back to overview tab
         cy.doMPVTabSelect("Overview");
         cy.get("[data-cy=details-element]").should("contain", "This is an old version");
-        cy.get("[data-cy=read-only-icon]").should("exist");
+        cy.get("[data-cy=read-only-icon]").should("be.visible");
         cy.get("[data-cy=collection-version-number]").should("contain", "1");
-        cy.get("[data-cy=collection-details-card]").should("contain", colName);
+        cy.get("[data-cy=collection-details-card]").should("contain", collName);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
 
@@ -823,7 +812,7 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
         cy.get("[data-cy=read-only-icon]").should("not.exist");
         cy.get("[data-cy=collection-version-number]").should("contain", "2");
-        cy.get("[data-cy=collection-details-card]").should("contain", colName);
+        cy.get("[data-cy=collection-details-card]").should("contain", collName);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").should("not.contain", "foo").and("contain", "bar");
 
@@ -843,7 +832,7 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
         cy.get("[data-cy=read-only-icon]").should("not.exist");
         cy.get("[data-cy=collection-version-number]").should("contain", "3");
-        cy.get("[data-cy=collection-details-card]").should("contain", colName + " renamed");
+        cy.get("[data-cy=collection-details-card]").should("contain", collName + " renamed");
         cy.get("[data-cy=collection-version-browser-select-3]").should("contain", "3").and("contain", "3 B");
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").should("not.contain", "foo").and("contain", "bar");
@@ -872,22 +861,21 @@ describe("Collection panel tests", function () {
         cy.doMPVTabSelect("Overview");
         cy.get("[data-cy=details-element]").should("not.contain", "This is an old version");
         cy.get("[data-cy=collection-version-number]").should("contain", "4");
-        cy.get("[data-cy=collection-details-card]").should("contain", colName);
+        cy.get("[data-cy=collection-details-card]").should("contain", collName);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").should("contain", "foo").and("contain", "bar");
     });
 
     it("copies selected files into new collection", () => {
+        const srcName = randomName();
+        cy.loginAs(activeUser);
+
         cy.createCollection(adminUser.token, {
-            name: `Test Collection ${Math.floor(Math.random() * 999999)}`,
+            name: srcName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        }).as("sourceCollection");
-
-        // Visit collection, check basic information
-        cy.loginAs(activeUser);
-        cy.get("@sourceCollection").then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
+        }).then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
@@ -898,64 +886,63 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=form-dialog]").contains("Projects").click();
         cy.get("[data-cy=form-submit-btn]").click();
 
-        cy.get("@sourceCollection")
-            .then(oldColl => goToCollectionByName(`Files extracted from: ${oldColl.name}`, activeUser.token));
+        cy.get("[data-cy=snackbar]").should("contain", "New collection created.");
+        goToCollectionByName(`Files extracted from: ${srcName}`, activeUser.token);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
     });
 
     it("copies selected files into existing collection", () => {
-        cy.createCollection(adminUser.token, {
-            name: `Test Collection ${Math.floor(Math.random() * 999999)}`,
-            owner_uuid: activeUser.user.uuid,
-            preserve_version: true,
-            manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        }).as("sourceCollection");
+        const srcName = randomName();
+        const dstName = randomName("Destination Collection ");
+
+        cy.loginAs(activeUser);
 
         cy.createCollection(adminUser.token, {
-            name: `Destination Collection ${Math.floor(Math.random() * 999999)}`,
+            name: dstName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: "",
-        }).as("destinationCollection");
+        }).as("dstCollection");
 
-        cy.loginAs(activeUser);
-        // Visit collection, check basic information
-        cy.get("@sourceCollection").then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
-
+        cy.createCollection(adminUser.token, {
+            name: srcName,
+            owner_uuid: activeUser.user.uuid,
+            preserve_version: true,
+            manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
+        }).then((srcCollection) => cy.goToPath(`/collections/${srcCollection.uuid}`));
+        // Now browsing src collection; check basic information
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
 
         cy.get("[data-cy=collection-files-panel-options-btn]").click();
         cy.get("[data-cy=context-menu]").contains("Copy selected into existing collection").click();
-
-        cy.get("@destinationCollection")
-            .its("name")
-            .then(destName => cy.get("[data-cy=form-dialog]").contains(destName).click());
-
+        cy.get("[data-cy=form-dialog]").contains(dstName).click();
         cy.get("[data-cy=form-submit-btn]").click();
+        cy.get("[data-cy=form-dialog]").should("not.exist");
 
-        cy.get("@destinationCollection").then(destinationCollection => cy.goToPath(`/collections/${destinationCollection.uuid}`));
+        // Visit dst collection
+        cy.get("@dstCollection").then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         cy.doMPVTabSelect("Overview");;
-        cy.get("@destinationCollection")
-            .its("name")
-            .then(destName => cy.get("main").contains(destName).should("exist"));
+        cy.get("main").contains(dstName).should("exist");
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").should("contain", "bar");
     });
 
     it("copies selected files into separate collections", () => {
+        const srcName = randomName();
+        const dstNameFoo = `File copied from collection ${srcName}/foo`;
+        const dstNameBar = `File copied from collection ${srcName}/bar`;
+
+        cy.loginAs(activeUser);
+
         cy.createCollection(adminUser.token, {
-            name: `Test Collection ${Math.floor(Math.random() * 999999)}`,
+            name: srcName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        }).as("sourceCollection");
-
-        // Visit collection, check basic information
-        cy.loginAs(activeUser);
-        cy.get("@sourceCollection").then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
+        }).then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         // Select both files
         cy.doMPVTabSelect("Files");
@@ -968,14 +955,13 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=form-dialog]").contains("Projects").click();
         cy.get("[data-cy=form-submit-btn]").click();
 
+        cy.get("[data-cy=snackbar]").should("contain", "New collections created.");
         // Verify created collections
-        cy.get("@sourceCollection")
-            .then(oldColl => goToCollectionByName(`File copied from collection ${oldColl.name}/foo`, activeUser.token));
+        goToCollectionByName(dstNameFoo, activeUser.token);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='foo']").should("be.visible");
 
-        cy.get("@sourceCollection")
-            .then(oldColl => goToCollectionByName(`File copied from collection ${oldColl.name}/bar`, activeUser.token));
+        goToCollectionByName(dstNameBar, activeUser.token);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='bar']").should("be.visible");
 
@@ -990,14 +976,16 @@ describe("Collection panel tests", function () {
     });
 
     it("moves selected files into new collection", () => {
+        const srcName = randomName();
+        const dstName = `Files moved from: ${srcName}`;
+
         cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: `Test Collection ${Math.floor(Math.random() * 999999)}`,
+            name: srcName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        }).as("testCollection")
-            .then(testCollection => cy.goToPath(`/collections/${testCollection.uuid}`));
+        }).then((collection) => cy.goToPath(`/collections/${collection.uuid}`));
 
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
@@ -1006,24 +994,19 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=context-menu]").contains("Move selected into new collection").click();
 
         cy.get("[data-cy=form-dialog]").contains("Projects").click();
-
         cy.get("[data-cy=form-submit-btn]").click();
 
-        cy.get("@testCollection").then(oldColl => goToCollectionByName(`Files moved from: ${oldColl.name}`, activeUser.token));
+        cy.get("[data-cy=snackbar]").should("contain", "Files have been moved to selected collection.");
+        goToCollectionByName(dstName, activeUser.token);
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy=collection-files-panel]").and("contain", "bar");
     });
 
     it("moves selected files into existing collection", () => {
-        const srcName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
-        const dstName = `Test Collection ${Math.floor(Math.random() * 999999)}`;
+        const srcName = randomName();
+        const dstName = randomName();
 
-        cy.createCollection(adminUser.token, {
-            name: srcName,
-            owner_uuid: activeUser.user.uuid,
-            preserve_version: true,
-            manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        }).as("srcCollection");
+        cy.loginAs(activeUser);
 
         cy.createCollection(adminUser.token, {
             name: dstName,
@@ -1032,38 +1015,47 @@ describe("Collection panel tests", function () {
             manifest_text: "",
         }).as("dstCollection");
 
-        cy.loginAs(activeUser);
-        cy.get("@srcCollection").then(srcCollection => cy.goToPath(`/collections/${srcCollection.uuid}`));
+        cy.createCollection(adminUser.token, {
+            name: srcName,
+            owner_uuid: activeUser.user.uuid,
+            preserve_version: true,
+            manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
+        }).then((srcCollection) => cy.goToPath(`/collections/${srcCollection.uuid}`));
 
+        // Now browsing src collection.
         cy.doMPVTabSelect("Files");
-        // FIXME: implicitly relying on "bar" being first.
-        cy.get("[data-cy=collection-files-panel] input[type=checkbox]").first().click();
+        // Click on checkbox next to "bar".
+        cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='bar'] input[type='checkbox']").click();
 
         cy.get("[data-cy=collection-files-panel-options-btn]").click();
         cy.get("[data-cy=context-menu]").contains("Move selected into existing collection").click();
 
         cy.get("[data-cy=form-dialog]").contains(dstName).click();
         cy.get("[data-cy=form-submit-btn]").click();
+        cy.get("[data-cy=form-dialog]").should("not.exist");
 
+        // Go to dst collection.
         cy.get("@dstCollection").then(dstCollection => cy.goToPath(`/collections/${dstCollection.uuid}`));
 
         cy.get("main").contains(dstName).should("exist");
         cy.doMPVTabSelect("Files");
-        cy.get("[data-cy=collection-files-panel]").should("contain", "bar");
+        cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='bar']").should("be.visible");
     });
 
     it("moves selected files into separate collections", () => {
+        const srcName = randomName();
+        const dstNameFoo = `File moved from collection ${srcName}/foo`;
+        const dstNameBar = `File moved from collection ${srcName}/bar`;
+
+        cy.loginAs(activeUser);
         cy.createCollection(adminUser.token, {
-            name: `Test Collection ${Math.floor(Math.random() * 999999)}`,
+            name: srcName,
             owner_uuid: activeUser.user.uuid,
             preserve_version: true,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:foo 0:3:bar\n",
-        }).as("sourceCollection");
+        }).then((srcCollection) => cy.goToPath(`/collections/${srcCollection.uuid}`));
 
-        // Visit collection, check basic information
-        cy.loginAs(activeUser);
-        cy.get("@sourceCollection").then(sourceCollection => cy.goToPath(`/collections/${sourceCollection.uuid}`));
-
+        // Now browsing src collection.
         cy.doMPVTabSelect("Files");
         // Select both files
         cy.get("[data-cy=collection-files-panel]").within(() => {
@@ -1076,15 +1068,17 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=context-menu]").contains("Move selected into separate collections").click();
         cy.get("[data-cy=form-dialog]").contains("Projects").click();
         cy.get("[data-cy=form-submit-btn]").click();
-        cy.get("[data-cy=form-dialog]").should("not.exist");
+        cy.get("[data-cy=snackbar]").should("contain", "New collections created.");
 
         // Verify created collections
-        cy.get("@sourceCollection").then(oldColl => goToCollectionByName(`File moved from collection ${oldColl.name}/foo`, activeUser.token));
+        goToCollectionByName(dstNameFoo, activeUser.token);
+        cy.get("main").contains(dstNameFoo).should("exist");
         cy.doMPVTabSelect("Files");
         cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='foo']").should("be.visible");
 
-        cy.get("@sourceCollection").then(oldColl => goToCollectionByName(`File moved from collection ${oldColl.name}/bar`, activeUser.token));
+        goToCollectionByName(dstNameBar, activeUser.token);
         cy.doMPVTabSelect("Files");
+        cy.get("main").contains(dstNameBar).should("exist");
         cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='bar']").should("be.visible");
     });
 
@@ -1097,7 +1091,7 @@ describe("Collection panel tests", function () {
         cy.get("[data-cy=side-panel-button]").click();
         cy.get("[data-cy=side-panel-new-collection]").click();
         // Name between brackets tests bugfix #17582
-        const collName = `[Test collection (${Math.floor(999999 * Math.random())})]`;
+        const collName = `[${randomName()}]`;
 
         // Select a storage class.
         cy.get("[data-cy=form-dialog]")
@@ -1128,28 +1122,26 @@ describe("Collection panel tests", function () {
         // Value field should not complain about being required just after
         // adding a new property. See #19732
         cy.get("[data-cy=form-dialog]").should("not.contain", "This field is required");
-
         cy.get("[data-cy=form-submit-btn]").click();
+
         // Confirm that the user was taken to the newly created collection
         cy.get("[data-cy=form-dialog]").should("not.exist");
         cy.get("[data-cy=breadcrumb-first]").should("contain", "Projects");
-        cy.waitForDom();
-        cy.get("[data-cy=breadcrumb-last]").should('exist', { timeout: 10000 });
         cy.get("[data-cy=breadcrumb-last]").should("contain", collName);
 
         // Navigate to Overview tab
         cy.doMPVTabSelect("Overview");
 
         // Verify details
-        cy.get("[data-cy=details-element]")
+        cy.get("[data-cy='details-panel-storage classes'] [data-cy='details-attribute-value']")
             .should("contain", "default")
             .and("contain", "foo")
-        cy.get("[data-cy=resource-properties]")
-            .should("contain", "Color: Magenta")
             .and("not.contain", "bar");
-        // Confirm that the collection's properties has the real values.
+        cy.get("[data-cy=resource-properties]")
+            .should("contain", "Color: Magenta");
+        // Confirm that the collection's properties have been committed.
         cy.doRequest("GET", "/arvados/v1/collections", null, {
-            filters: `[["name", "=", "${collName}"]]`,
+            filters: JSON.stringify([["name", "=", collName]]),
         })
             .its("body.items")
             .then(collArray => {
@@ -1160,34 +1152,55 @@ describe("Collection panel tests", function () {
 
     it("shows responsible person for collection if available", () => {
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: randomName(),
             owner_uuid: activeUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
         }).as("testCollection1");
 
         cy.createCollection(adminUser.token, {
-            name: `Test collection ${Math.floor(Math.random() * 999999)}`,
+            name: randomName(),
             owner_uuid: adminUser.user.uuid,
             manifest_text: ". 37b51d194a7513e45b56f6524f2d51f2+3 0:3:bar\n",
         })
             .as("testCollection2")
-            .then(function (testCollection2) {
+            .then((testCollection2) => {
                 cy.shareWith(adminUser.token, activeUser.user.uuid, testCollection2.uuid, "can_write");
             });
 
-        cy.getAll("@testCollection1", "@testCollection2").then(function ([testCollection1, testCollection2]) {
-            cy.loginAs(activeUser);
+        cy.loginAs(activeUser);
+        cy.get("@testCollection1").then((testCollection1) => cy.goToPath(`/collections/${testCollection1.uuid}`));
+        // Navigate to Overview tab
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=responsible-person-wrapper]")
+            .should("contain", activeUser.user.uuid);
 
-            cy.goToPath(`/collections/${testCollection1.uuid}`);
-            // Navigate to Overview tab
-            cy.doMPVTabSelect("Overview");
-            cy.get("[data-cy=responsible-person-wrapper]").contains(activeUser.user.uuid);
+        cy.get("@testCollection2").then((testCollection2) => cy.goToPath(`/collections/${testCollection2.uuid}`));
+        // Navigate to Overview tab
+        cy.doMPVTabSelect("Overview");
+        cy.get("[data-cy=responsible-person-wrapper]")
+            .should("contain", adminUser.user.uuid);
+    });
 
-            cy.goToPath(`/collections/${testCollection2.uuid}`);
-            // Navigate to Overview tab
-            cy.doMPVTabSelect("Overview");
-            cy.get("[data-cy=responsible-person-wrapper]").contains(adminUser.user.uuid);
+    it('displays the correct breadcrumbs after moving a collection to trash', () => {
+        // See old redmine issue #22618
+        const collName = randomName("Breadcrumb Test Collection ");
+        cy.createCollection(adminUser.token, {
+            name: collName,
+            owner_uuid: activeUser.user.uuid,
+            manifest_text: "",
         });
+
+        cy.loginAs(activeUser);
+        // Go to home projects
+        cy.goToPath(`/projects/${activeUser.user.uuid}`);
+
+        // Right click on the item in listing
+        cy.get('[data-cy=data-table-row]').contains(collName).rightclick();
+        cy.get('[data-cy=context-menu]').should('exist');
+        // Move to trash
+        cy.get('[data-cy=context-move-to-trash]').click();
+
+        cy.get("[data-cy=breadcrumb-first]").should("contain", "Home Projects");
     });
 
     describe("file upload", () => {
@@ -1335,32 +1348,6 @@ describe("Collection panel tests", function () {
             });
         });
 
-        it('displays the correct breadcrumbs after moving a collection to trash', () => {
-            const breadcrumbTestCollectionName = `Breadcrumb Test Collection ${Math.floor(Math.random() * 999999)}`;
-            cy.loginAs(activeUser);
-            cy.goToPath(`/projects/${activeUser.user.uuid}`);
-
-            cy.get("[data-cy=side-panel-button]").click();
-            cy.get("[data-cy=side-panel-new-collection]").click();
-            cy.get("[data-cy=form-dialog]")
-                .should("contain", "New collection")
-                .within(() => {
-                    cy.get("[data-cy=name-field]").within(() => {
-                        cy.get("input").type(breadcrumbTestCollectionName);
-                    });
-                    cy.get("[data-cy=form-submit-btn]").click();
-                });
-            cy.get("[data-cy=form-dialog]").should("not.exist");
-
-            cy.get("[data-cy=side-panel-tree]").contains("Home Projects").click();
-            cy.waitForDom()
-            cy.get('[data-cy=data-table-row]').contains(breadcrumbTestCollectionName).should('exist').rightclick();
-            cy.get('[data-cy=context-menu]').should('exist');
-            cy.get('[data-cy=context-move-to-trash]').click();
-
-            cy.waitForDom();
-            cy.get("[data-cy=breadcrumb-first]").should("contain", "Home Projects");
-        });
     });
 
     describe("zip download", () => {

--- a/services/workbench2/cypress/e2e/collection.cy.js
+++ b/services/workbench2/cypress/e2e/collection.cy.js
@@ -1133,7 +1133,7 @@ describe("Collection panel tests", function () {
         cy.doMPVTabSelect("Overview");
 
         // Verify details
-        cy.get("[data-cy='details-panel-storage classes'] [data-cy='details-attribute-value']")
+        cy.get("[data-cy='details-panel-storage-classes'] [data-cy='details-attribute-value']")
             .should("contain", "default")
             .and("contain", "foo")
             .and("not.contain", "bar");

--- a/services/workbench2/cypress/e2e/collection.cy.js
+++ b/services/workbench2/cypress/e2e/collection.cy.js
@@ -5,10 +5,9 @@
 const path = require("path");
 require('cypress-plugin-tab');
 
-// It can be tricky to mimick the user's navigation and eyeballing for a newly
-// created (but not shown) collection by its known (and unique) name, which can
-// be noisy, time consuming, and a bit flaky. We locate the collection by API
-// directly and jump to it.
+// It can be tricky to mimick the user's search for a collection by its known
+// (and unique) name, which can be noisy, time consuming, and a bit flaky. We
+// locate the collection by API directly and jump to it.
 function goToCollectionByName(collectionName, token) {
     return cy.doRequest("GET", "/arvados/v1/collections", null, {
         filters: JSON.stringify([["name", "=", collectionName]]),
@@ -16,8 +15,12 @@ function goToCollectionByName(collectionName, token) {
         select: JSON.stringify(["uuid"]),
         count: "none"
     }, token, true)
-        .its("body.items.0.uuid")
-        .then(uuid => cy.goToPath(`/collections/${uuid}`));
+        .then((response) => {
+            // Not using Cypress "its" command, because "its" retries, yet we
+            // want the following line to fail fast.
+            const uuid = response.body.items[0].uuid;
+            return cy.goToPath(`/collections/${uuid}`);
+        });
 }
 
 describe("Collection panel tests", function () {

--- a/services/workbench2/cypress/support/commands.js
+++ b/services/workbench2/cypress/support/commands.js
@@ -330,10 +330,7 @@ Cypress.Commands.add("createVirtualMachine", (token, data) => {
 Cypress.Commands.add("getResource", (token, suffix, uuid) => {
     return cy
         .doRequest("GET", `/arvados/v1/${suffix}/${uuid}`, null, {}, token)
-        .its("body")
-        .then(function (resource) {
-            return resource;
-        });
+        .its("body");
 });
 
 Cypress.Commands.add("createResource", (token, suffix, data, keep = false) => {

--- a/services/workbench2/src/components/details-attribute/details-attribute.tsx
+++ b/services/workbench2/src/components/details-attribute/details-attribute.tsx
@@ -9,6 +9,7 @@ import { CustomStyleRulesCallback } from 'common/custom-theme';
 import { WithStyles } from '@mui/styles';
 import withStyles from '@mui/styles/withStyles';
 import { Tooltip } from '@mui/material';
+import kebabCase from 'lodash/kebabCase';
 import { CopyIcon } from 'components/icon/icon';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { ArvadosTheme } from 'common/custom-theme';
@@ -119,7 +120,7 @@ interface DetailsAttributeComponentProps {
 
 export const DetailsAttributeComponent = withStyles(styles)(
     (props: DetailsAttributeDataProps & WithStyles<CssRules> & DetailsAttributeComponentProps) =>
-        <Typography component="div" className={props.classes.attribute} data-cy={`details-panel-${props.label.toLowerCase()}`}>
+        <Typography component="div" className={props.classes.attribute} data-cy={`details-panel-${kebabCase(props.label)}`}>
             <Typography component="div" className={classnames([props.classes.label, props.classLabel])}>{props.label}{props.button}</Typography>
             <Typography
                 onClick={props.onValueClick}


### PR DESCRIPTION
`491-clean-up-cypress-collection-e2e-tests-for-maintainability-and-reliability` @ e09fbdba94730a8bd5abb7f8d90832327ddffe31

* For this branch (collections e2e testing) only:
  https://ci.arvados.org/job/developer-run-tests/5179/
* For recent WB testing changes (merged bundle of this branch, `514-wb-fix-favorites-e2e-tests`, and `514-wb-various-e2e-test-fixes`)
  https://ci.arvados.org/job/developer-run-tests/5174/

* All agreed upon points are implemented / addressed.  Describe changes from pre-implementation design.
  * This branch fixes #491 (moving files to separate collections) and the "uploads and maintains nested folder structure" test in the same test spec file. The latter largely only cropped up in live testing.
  * This is a large branch by diff count, so I'll try to explain what was done here.
    * The `collection.cy.js` spec file is among the largest, slowest, and flakiest Cypress e2e tests. Especially in live testing, at one point errors emerged continually in different places while I was testing it locally.
    * One of the mis-patterns in the spec file is the pyramiding of `.then()` callbacks. Coupled with Cypress's own limitations for error reporting, this often made it hard to identify where an error occurred in a large, monolithic callback. For this reason, I did some large, but mostly mechanical pyramid-flattening, using chaining (recommended by Cypress) rather than nesting, to help better isolate issues.
    * For #491, the main issue seemed to be that the complexity and rapid burst of DOM changes caused by navigating to the newly created collections using point-and-click alone. The UI-based navigation isn't necessary: it isn't in the objective of the test, merely to set up state so we can test our objective (that the moved files are in the new collections). So we set up state programmatically (following the [Cypress guide](https://docs.cypress.io/app/guides/test-performance#Set-up-state-programmatically-not-through-the-UI)) and land on the destination collections directly. This largely resolved the flakiness of the test. (This transformation was done in eff919441bf72491486530f730a71f54cf3b238c).
    * As for the "it uploads and maintains nested folder structure" test flake in #514 discovered in live testing, the cause was clicking on a detached element while the DOM was doing complex mutation. The original, offending code was
      ```javascript
      cy.get("[data-cy=collection-files-panel]").contains("foo").should("exist").click();
      ```
      and the `.contains()` query in the chain was expensive and flaky. The intention was to select the row containing the file `foo`, and in the revised code we use the precise selector for the element
      ```javascript
      cy.get("[data-cy='collection-files-panel'] [data-subfolder-path='foo']").click();
      ```
      and `cy.get()` retries automatically until the precise element was located.
    * I did more cleanup as I repeatedly ran the spec in live testing. Remove excessive waits. Simplify queries. Remove unnecessary assertions. Until the tests ran.
* Anything not implemented (discovered or discussed during work) has a follow-up story.
  * _N/A_
* Code is tested and passing, both automated and manual, what manual testing was done is described.
  * Headless tests: see above.
  * Live testing: manually ran many, many times in Cypress app.
* The tested code incorporates recent main branch changes.
  * _Yes_
* New or changed UI/UX has gotten feedback from stakeholders.
  * _N/A_, no user-visible change.
* Documentation has been updated.
  * _N/A_
* Behaves appropriately at the intended scale (describe intended scale).
  * _N/A_
* Considered backwards and forwards compatibility issues between client and server.
  * _N/A_, not affected.
* Follows our [coding standards](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md) and [GUI style guidelines](https://github.com/arvados/arvados/blob/main/doc/development/CodingStandards.md#workbench-design-guidelines)
  * _Mostly_ for new code.

Partially address #514.
Closes #491.